### PR TITLE
Get food search route

### DIFF
--- a/__fixtures__/chicken_recipes.json
+++ b/__fixtures__/chicken_recipes.json
@@ -1,6554 +1,6556 @@
 {
-  "q": "chicken",
-  "from": 0,
-  "to": 10,
-  "params": {
-    "sane": [],
-    "q": [
-      "chicken"
-    ],
-    "app_key": [
-      "042170f2d26ea42fc061e26221087fba"
-    ],
-    "to": [
-      "10"
-    ],
-    "time": [
-      "1+"
-    ],
-    "app_id": [
-      "671db6f5"
+  "data": {
+    "q": "chicken",
+    "from": 0,
+    "to": 10,
+    "params": {
+      "sane": [],
+      "q": [
+        "chicken"
+      ],
+      "app_key": [
+        "042170f2d26ea42fc061e26221087fba"
+      ],
+      "to": [
+        "10"
+      ],
+      "time": [
+        "1+"
+      ],
+      "app_id": [
+        "671db6f5"
+      ]
+    },
+    "more": true,
+    "count": 91409,
+    "hits": [
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_b79327d05b8e5b838ad6cfd9576b30b6",
+          "label": "checking to see if this works",
+          "image": "https://www.edamam.com/web-img/e42/e42f9119813e890af34c259785ae1cfb.jpg",
+          "source": "Serious Eats",
+          "url": "http://www.seriouseats.com/recipes/2011/12/chicken-vesuvio-recipe.html",
+          "shareAs": "http://www.edamam.com/recipe/chicken-vesuvio-b79327d05b8e5b838ad6cfd9576b30b6/chicken",
+          "yield": 4.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Peanut-Free",
+            "Tree-Nut-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1/2 cup olive oil",
+            "5 cloves garlic, peeled",
+            "2 large russet potatoes, peeled and cut into chunks",
+            "1 3-4 pound chicken, cut into 8 pieces (or 3 pound chicken legs)",
+            "3/4 cup white wine",
+            "3/4 cup chicken stock",
+            "3 tablespoons chopped parsley",
+            "1 tablespoon dried oregano",
+            "Salt and pepper",
+            "1 cup frozen peas, thawed"
+          ],
+          "ingredients": [
+            {
+              "text": "1/2 cup olive oil",
+              "weight": 108.0
+            },
+            {
+              "text": "5 cloves garlic, peeled",
+              "weight": 15.0
+            },
+            {
+              "text": "2 large russet potatoes, peeled and cut into chunks",
+              "weight": 738.0
+            },
+            {
+              "text": "1 3-4 pound chicken, cut into 8 pieces (or 3 pound chicken legs)",
+              "weight": 1587.5732950000001
+            },
+            {
+              "text": "3/4 cup white wine",
+              "weight": 169.5
+            },
+            {
+              "text": "3/4 cup chicken stock",
+              "weight": 180.0
+            },
+            {
+              "text": "3 tablespoons chopped parsley",
+              "weight": 11.399999999999999
+            },
+            {
+              "text": "1 tablespoon dried oregano",
+              "weight": 5.9999999998985585
+            },
+            {
+              "text": "Salt and pepper",
+              "weight": 17.696839769999393
+            },
+            {
+              "text": "Salt and pepper",
+              "weight": 8.848419884999696
+            },
+            {
+              "text": "1 cup frozen peas, thawed",
+              "weight": 134.0
+            }
+          ],
+          "calories": 4230.305691201081,
+          "totalWeight": 2972.9302457924105,
+          "totalTime": 60.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 4230.305691201081,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 274.57692448260667,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 62.54398613465762,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 1.047163345382,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 147.41199987638942,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 47.3914730818309,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 177.8427845163874,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 21.103850230861813,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 16.29572988725985,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 230.99085117764236,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 815.06238045,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 6879.517981530534,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 447.3120299727316,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 485.56685143215077,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 5950.924381476969,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 23.630588288190932,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 18.41378763939628,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 2234.2507691001497,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 637.9185080148637,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 103.79879744959767,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.73140519783562,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.926703964512464,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 87.03578409848684,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 6.914193343964289,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 283.3102218162095,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 283.3102218162095,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 3.34660450586,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 107.95498406,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 20.17637308858548,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 371.9191109601138,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 211.51528456005406,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 422.42603766554873,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 312.7199306732881,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 59.28092817212914,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 84.41540092344725,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 461.9817023552847,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 271.68746015,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 286.64658256377226,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 44.73120299727315,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 115.61115510289305,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 126.61541237185041,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 131.28104604550518,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 167.3980694490571,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 319.17868130002137,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 70.87983422387376,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 115.33199716621964,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 144.28376648630166,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 148.20799727018954,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 543.9736506155427,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 531.8610264587915,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 70.82755545405237,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 139.44185441083332,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 719.6998937333334,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 134.5091539239032,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 309.93259246676155,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 274.57692448260667,
+              "hasRDI": true,
+              "daily": 422.42603766554873,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 62.54398613465762,
+                  "hasRDI": true,
+                  "daily": 312.7199306732881,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 1.047163345382,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 147.41199987638942,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 47.3914730818309,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 177.8427845163874,
+              "hasRDI": true,
+              "daily": 59.28092817212914,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 156.7389342855256,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 21.103850230861813,
+                  "hasRDI": true,
+                  "daily": 84.41540092344725,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 16.29572988725985,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 230.99085117764236,
+              "hasRDI": true,
+              "daily": 461.9817023552847,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 815.06238045,
+              "hasRDI": true,
+              "daily": 271.68746015,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 6879.517981530534,
+              "hasRDI": true,
+              "daily": 286.64658256377226,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 447.3120299727316,
+              "hasRDI": true,
+              "daily": 44.73120299727315,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 485.56685143215077,
+              "hasRDI": true,
+              "daily": 115.61115510289305,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 5950.924381476969,
+              "hasRDI": true,
+              "daily": 126.61541237185041,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 23.630588288190932,
+              "hasRDI": true,
+              "daily": 131.28104604550518,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 18.41378763939628,
+              "hasRDI": true,
+              "daily": 167.3980694490571,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 2234.2507691001497,
+              "hasRDI": true,
+              "daily": 319.17868130002137,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 637.9185080148637,
+              "hasRDI": true,
+              "daily": 70.87983422387376,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 103.79879744959767,
+              "hasRDI": true,
+              "daily": 115.33199716621964,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.73140519783562,
+              "hasRDI": true,
+              "daily": 144.28376648630166,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.926703964512464,
+              "hasRDI": true,
+              "daily": 148.20799727018954,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 87.03578409848684,
+              "hasRDI": true,
+              "daily": 543.9736506155427,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 6.914193343964289,
+              "hasRDI": true,
+              "daily": 531.8610264587915,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 283.3102218162095,
+              "hasRDI": true,
+              "daily": 70.82755545405237,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 283.3102218162095,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 3.34660450586,
+              "hasRDI": true,
+              "daily": 139.44185441083332,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 107.95498406,
+              "hasRDI": true,
+              "daily": 719.6998937333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 20.17637308858548,
+              "hasRDI": true,
+              "daily": 134.5091539239032,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 371.9191109601138,
+              "hasRDI": true,
+              "daily": 309.93259246676155,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_584ac5e486c088b3c8409c252d7f290c",
+          "label": "Chicken Gravy",
+          "image": "https://www.edamam.com/web-img/fd1/fd1afed1849c44f5185720394e363b4e.jpg",
+          "source": "Martha Stewart",
+          "url": "http://www.marthastewart.com/332664/chicken-gravy",
+          "shareAs": "http://www.edamam.com/recipe/chicken-gravy-584ac5e486c088b3c8409c252d7f290c/chicken",
+          "yield": 6.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Gluten",
+            "Wheat",
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "4 cups chicken bones and wings",
+            "2 tablespoons unsalted butter, softened",
+            "2 tablespoons all-purpose flour",
+            "4 cups homemade bruce and eric bromberg's chicken stock, or store-bought low-sodium chicken stock",
+            "1 tablespoon fresh thyme leaves",
+            "Coarse salt and freshly ground black pepper"
+          ],
+          "ingredients": [
+            {
+              "text": "4 cups chicken bones and wings",
+              "weight": 568.0
+            },
+            {
+              "text": "2 tablespoons unsalted butter, softened",
+              "weight": 28.4
+            },
+            {
+              "text": "2 tablespoons all-purpose flour",
+              "weight": 15.6
+            },
+            {
+              "text": "4 cups homemade bruce and eric bromberg's chicken stock, or store-bought low-sodium chicken stock",
+              "weight": 960.0
+            },
+            {
+              "text": "1 tablespoon fresh thyme leaves",
+              "weight": 7.499999999873198
+            },
+            {
+              "text": "Coarse salt and freshly ground black pepper",
+              "weight": 0.0
+            },
+            {
+              "text": "Coarse salt and freshly ground black pepper",
+              "weight": 4.738499999999619
+            }
+          ],
+          "calories": 1092.360634999871,
+          "totalWeight": 1584.2384999998728,
+          "totalTime": 270.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 1092.360634999871,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 68.98859509999785,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 33.47207691999941,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.9309519999999999,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 8.655028514999897,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 2.2254302299993216,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 28.305420749968757,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 2.670040499982152,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 1.3374863999999977,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 84.4422101499929,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 242.82,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 1116.6586999999886,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 98.92255499948476,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 33.702834999796465,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 957.7576649992228,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 11.898378349977836,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 1.2868981499977004,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 327.10082999986497,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 213.3853949996981,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 12.00749999979699,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 0.13259757999993874,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 0.418574299999402,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 14.275913054997684,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.14360503499955762,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 50.42854499994287,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 9.556544999942874,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 24.024,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 1.00828,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 17.04,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 0.7440403999999959,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 9.791724499999376,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 54.618031749993555,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 106.13630015384285,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 167.36038459999705,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 9.435140249989585,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 10.680161999928607,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 168.8844202999858,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 80.94,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 46.527445833332855,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 9.892255499948476,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 8.024484523761062,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 20.377822659557932,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 66.1021019443213,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 11.699074090888184,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 46.72868999998071,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 23.70948833329979,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 13.3416666664411,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 11.049798333328228,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 32.19802307687708,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 89.22445659373552,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 11.046541153812123,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 12.607136249985718,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 42.01166666666667,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 113.6,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 4.960269333333306,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 8.159770416666145,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 68.98859509999785,
+              "hasRDI": true,
+              "daily": 106.13630015384285,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 33.47207691999941,
+                  "hasRDI": true,
+                  "daily": 167.36038459999705,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.9309519999999999,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 8.655028514999897,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 2.2254302299993216,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 28.305420749968757,
+              "hasRDI": true,
+              "daily": 9.435140249989585,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 25.635380249986603,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 2.670040499982152,
+                  "hasRDI": true,
+                  "daily": 10.680161999928607,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 1.3374863999999977,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 84.4422101499929,
+              "hasRDI": true,
+              "daily": 168.8844202999858,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 242.82,
+              "hasRDI": true,
+              "daily": 80.94,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 1116.6586999999886,
+              "hasRDI": true,
+              "daily": 46.527445833332855,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 98.92255499948476,
+              "hasRDI": true,
+              "daily": 9.892255499948476,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 33.702834999796465,
+              "hasRDI": true,
+              "daily": 8.024484523761062,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 957.7576649992228,
+              "hasRDI": true,
+              "daily": 20.377822659557932,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 11.898378349977836,
+              "hasRDI": true,
+              "daily": 66.1021019443213,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 1.2868981499977004,
+              "hasRDI": true,
+              "daily": 11.699074090888184,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 327.10082999986497,
+              "hasRDI": true,
+              "daily": 46.72868999998071,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 213.3853949996981,
+              "hasRDI": true,
+              "daily": 23.70948833329979,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 12.00749999979699,
+              "hasRDI": true,
+              "daily": 13.3416666664411,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 0.13259757999993874,
+              "hasRDI": true,
+              "daily": 11.049798333328228,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 0.418574299999402,
+              "hasRDI": true,
+              "daily": 32.19802307687708,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 14.275913054997684,
+              "hasRDI": true,
+              "daily": 89.22445659373552,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.14360503499955762,
+              "hasRDI": true,
+              "daily": 11.046541153812123,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 50.42854499994287,
+              "hasRDI": true,
+              "daily": 12.607136249985718,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 9.556544999942874,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 24.024,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 1.00828,
+              "hasRDI": true,
+              "daily": 42.01166666666667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 17.04,
+              "hasRDI": true,
+              "daily": 113.6,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 0.7440403999999959,
+              "hasRDI": true,
+              "daily": 4.960269333333306,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 9.791724499999376,
+              "hasRDI": true,
+              "daily": 8.159770416666145,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_1817e7fccea9ae39d09c0e2c7fb86cb2",
+          "label": "Kreplach (Chicken Dumplings)",
+          "image": "https://www.edamam.com/web-img/4dd/4dd1c7a0d8b00e8929bd6babf0968ba2.jpg",
+          "source": "Tasting Table",
+          "url": "https://www.tastingtable.com/entry_detail/chefs_recipes/10154/Matzo_balls_watch_your_back.htm",
+          "shareAs": "http://www.edamam.com/recipe/kreplach-chicken-dumplings-1817e7fccea9ae39d09c0e2c7fb86cb2/chicken",
+          "yield": 8.0,
+          "dietLabels": [
+            "Low-Fat"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1½ teaspoons canola oil",
+            "½ small shallot, finely chopped",
+            "1 cup (about ½ pound) raw, boneless chicken meat (preferably from 3 boneless chicken thighs), roughly chopped",
+            "⅔ cup (about ¼ pound) chicken skin and fat (reserved from the 3 chicken thighs)",
+            "2 chicken livers (optional)",
+            "2 garlic cloves, finely chopped",
+            "¼ cup finely chopped chives, plus extra for serving",
+            "1¼ teaspoons kosher salt",
+            "¾ teaspoon freshly ground black pepper",
+            "30 to 34 square wonton wrappers",
+            "8 cups store-bought or homemade chicken broth"
+          ],
+          "ingredients": [
+            {
+              "text": "1½ teaspoons canola oil",
+              "weight": 6.75
+            },
+            {
+              "text": "½ small shallot, finely chopped",
+              "weight": 20.0
+            },
+            {
+              "text": "1 cup (about ½ pound) raw, boneless chicken meat (preferably from 3 boneless chicken thighs), roughly chopped",
+              "weight": 226.796185
+            },
+            {
+              "text": "⅔ cup (about ¼ pound) chicken skin and fat (reserved from the 3 chicken thighs)",
+              "weight": 113.3980925
+            },
+            {
+              "text": "2 garlic cloves, finely chopped",
+              "weight": 6.0
+            },
+            {
+              "text": "1¼ teaspoons kosher salt",
+              "weight": 6.067708333641094
+            },
+            {
+              "text": "¾ teaspoon freshly ground black pepper",
+              "weight": 1.7249999999999999
+            },
+            {
+              "text": "30 to 34 square wonton wrappers",
+              "weight": 1024.0
+            },
+            {
+              "text": "8 cups store-bought or homemade chicken broth",
+              "weight": 1920.0
+            }
+          ],
+          "calories": 4278.876994575,
+          "totalWeight": 3318.6692775,
+          "totalTime": 10.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 4278.876994575,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 71.07698066225001,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 16.3080290662,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.12305087862500003,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 27.3695310345,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 17.908023754475003,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 667.4022327312499,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 19.634425000000004,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 31.98104,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 217.04189635250003,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 419.64746015000003,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 8873.130517375,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 599.935158675,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 367.36045290000004,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 3720.1606223500003,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 41.737490575500004,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 15.084024142250001,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1942.1379052750003,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 122.99470087500002,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 12.528312255,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 6.260764822575,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 6.002902816824999,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 109.98667621027502,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 2.995234726475,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 1494.7109257250002,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 296.630925725,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 706.5600000000001,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 1.7470140580000002,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 14.741752025000002,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 2.4996979827500003,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 18.2022662725,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 213.94384972875,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 109.34920101884616,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 81.54014533099999,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 222.46741091041665,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 78.53770000000002,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 434.08379270500006,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 139.88248671666668,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 369.7137715572917,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 59.99351586750001,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 87.4667745,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 79.15235366702129,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 231.8749476416667,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 137.12749220227272,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 277.4482721821429,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 13.666077875000003,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 13.920346949999999,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 521.73040188125,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 461.7617551403845,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 687.4167263142189,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 230.40267126730768,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 373.6777314312501,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 72.79225241666668,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 98.27834683333336,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 16.664653218333335,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 15.168555227083335,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 71.07698066225001,
+              "hasRDI": true,
+              "daily": 109.34920101884616,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 16.3080290662,
+                  "hasRDI": true,
+                  "daily": 81.54014533099999,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.12305087862500003,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 27.3695310345,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 17.908023754475003,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 667.4022327312499,
+              "hasRDI": true,
+              "daily": 222.46741091041665,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 647.76780773125,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 19.634425000000004,
+                  "hasRDI": true,
+                  "daily": 78.53770000000002,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 31.98104,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 217.04189635250003,
+              "hasRDI": true,
+              "daily": 434.08379270500006,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 419.64746015000003,
+              "hasRDI": true,
+              "daily": 139.88248671666668,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 8873.130517375,
+              "hasRDI": true,
+              "daily": 369.7137715572917,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 599.935158675,
+              "hasRDI": true,
+              "daily": 59.99351586750001,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 367.36045290000004,
+              "hasRDI": true,
+              "daily": 87.4667745,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 3720.1606223500003,
+              "hasRDI": true,
+              "daily": 79.15235366702129,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 41.737490575500004,
+              "hasRDI": true,
+              "daily": 231.8749476416667,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 15.084024142250001,
+              "hasRDI": true,
+              "daily": 137.12749220227272,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1942.1379052750003,
+              "hasRDI": true,
+              "daily": 277.4482721821429,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 122.99470087500002,
+              "hasRDI": true,
+              "daily": 13.666077875000003,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 12.528312255,
+              "hasRDI": true,
+              "daily": 13.920346949999999,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 6.260764822575,
+              "hasRDI": true,
+              "daily": 521.73040188125,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 6.002902816824999,
+              "hasRDI": true,
+              "daily": 461.7617551403845,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 109.98667621027502,
+              "hasRDI": true,
+              "daily": 687.4167263142189,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 2.995234726475,
+              "hasRDI": true,
+              "daily": 230.40267126730768,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 1494.7109257250002,
+              "hasRDI": true,
+              "daily": 373.6777314312501,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 296.630925725,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 706.5600000000001,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 1.7470140580000002,
+              "hasRDI": true,
+              "daily": 72.79225241666668,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 14.741752025000002,
+              "hasRDI": true,
+              "daily": 98.27834683333336,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 2.4996979827500003,
+              "hasRDI": true,
+              "daily": 16.664653218333335,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 18.2022662725,
+              "hasRDI": true,
+              "daily": 15.168555227083335,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_a798c432f454674f165d4a52e4fd83b4",
+          "label": "Chicken Marsala",
+          "image": "https://www.edamam.com/web-img/4de/4de0bd5b79b1d8f701bbf02d2afd0b80.jpg",
+          "source": "Saveur",
+          "url": "http://www.saveur.com/classic-chicken-marsala-recipe",
+          "shareAs": "http://www.edamam.com/recipe/chicken-marsala-a798c432f454674f165d4a52e4fd83b4/chicken",
+          "yield": 4.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1¼ lb. chicken cutlets, pounded until ¼\" thick (about 8)",
+            "Kosher salt and freshly ground black pepper, to taste",
+            "⅓ cup flour",
+            "5 tbsp. olive oil",
+            "5 tbsp. unsalted butter",
+            "8 oz. white button mushrooms",
+            "2 tbsp. minced shallots",
+            "1 clove garlic, minced",
+            "⅓ cup dry marsala wine",
+            "⅓ cup chicken stock"
+          ],
+          "ingredients": [
+            {
+              "text": "1¼ lb. chicken cutlets, pounded until ¼\" thick (about 8)",
+              "weight": 566.9904625
+            },
+            {
+              "text": "Kosher salt and freshly ground black pepper, to taste",
+              "weight": 0.0
+            },
+            {
+              "text": "Kosher salt and freshly ground black pepper, to taste",
+              "weight": 3.4668599425
+            },
+            {
+              "text": "⅓ cup flour",
+              "weight": 41.666666666666664
+            },
+            {
+              "text": "5 tbsp. olive oil",
+              "weight": 67.5
+            },
+            {
+              "text": "5 tbsp. unsalted butter",
+              "weight": 71.0
+            },
+            {
+              "text": "8 oz. white button mushrooms",
+              "weight": 226.796185
+            },
+            {
+              "text": "2 tbsp. minced shallots",
+              "weight": 20.0
+            },
+            {
+              "text": "1 clove garlic, minced",
+              "weight": 3.0
+            },
+            {
+              "text": "⅓ cup dry marsala wine",
+              "weight": 78.66666666666666
+            },
+            {
+              "text": "⅓ cup chicken stock",
+              "weight": 80.0
+            }
+          ],
+          "calories": 2404.220574655675,
+          "totalWeight": 1159.0868407758335,
+          "totalTime": 121.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2404.220574655675,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 179.82217777770884,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 61.362736418732936,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 2.9227199856249997,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 86.36322076247507,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 21.131794556559488,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 50.76457923089541,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 4.9730774154525,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 8.157319033298666,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 133.25525362910906,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 517.923896,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 500.47383928016666,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 130.01935930360833,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 195.47760277667496,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 2317.673787769159,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 7.296109114583418,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 6.441152828649084,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1303.0490958924831,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 623.453763184475,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 7.458719885000001,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 0.6481364432962334,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.5341029047215005,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 66.4070196265928,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 3.4687993794160086,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 86.464336140225,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 86.464336140225,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 2.1391860465,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 149.19420695,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 12.982459210651998,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 51.776249725872496,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 120.21102873278376,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 276.64950427339824,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 306.8136820936647,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 16.92152641029847,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 19.89230966181,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 266.5105072582181,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 172.64129866666667,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 20.85307663667361,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 13.001935930360833,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 46.542286375398795,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 49.312208250407636,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 40.53393952546343,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 58.55593480590076,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 186.1498708417833,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 69.27264035383055,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 8.28746653888889,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 54.01137027468612,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 118.00791574780773,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 415.043872666205,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 266.8307214935391,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 21.61608403505625,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 89.1327519375,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 994.6280463333333,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 86.54972807101332,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 43.14687477156041,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 179.82217777770884,
+              "hasRDI": true,
+              "daily": 276.64950427339824,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 61.362736418732936,
+                  "hasRDI": true,
+                  "daily": 306.8136820936647,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 2.9227199856249997,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 86.36322076247507,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 21.131794556559488,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 50.76457923089541,
+              "hasRDI": true,
+              "daily": 16.92152641029847,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 45.791501815442906,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 4.9730774154525,
+                  "hasRDI": true,
+                  "daily": 19.89230966181,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 8.157319033298666,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 133.25525362910906,
+              "hasRDI": true,
+              "daily": 266.5105072582181,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 517.923896,
+              "hasRDI": true,
+              "daily": 172.64129866666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 500.47383928016666,
+              "hasRDI": true,
+              "daily": 20.85307663667361,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 130.01935930360833,
+              "hasRDI": true,
+              "daily": 13.001935930360833,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 195.47760277667496,
+              "hasRDI": true,
+              "daily": 46.542286375398795,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 2317.673787769159,
+              "hasRDI": true,
+              "daily": 49.312208250407636,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 7.296109114583418,
+              "hasRDI": true,
+              "daily": 40.53393952546343,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 6.441152828649084,
+              "hasRDI": true,
+              "daily": 58.55593480590076,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1303.0490958924831,
+              "hasRDI": true,
+              "daily": 186.1498708417833,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 623.453763184475,
+              "hasRDI": true,
+              "daily": 69.27264035383055,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 7.458719885000001,
+              "hasRDI": true,
+              "daily": 8.28746653888889,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 0.6481364432962334,
+              "hasRDI": true,
+              "daily": 54.01137027468612,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.5341029047215005,
+              "hasRDI": true,
+              "daily": 118.00791574780773,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 66.4070196265928,
+              "hasRDI": true,
+              "daily": 415.043872666205,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 3.4687993794160086,
+              "hasRDI": true,
+              "daily": 266.8307214935391,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 86.464336140225,
+              "hasRDI": true,
+              "daily": 21.61608403505625,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 86.464336140225,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 2.1391860465,
+              "hasRDI": true,
+              "daily": 89.1327519375,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 149.19420695,
+              "hasRDI": true,
+              "daily": 994.6280463333333,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 12.982459210651998,
+              "hasRDI": true,
+              "daily": 86.54972807101332,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 51.776249725872496,
+              "hasRDI": true,
+              "daily": 43.14687477156041,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_3b7cb2359876b5b27920156479e3286f",
+          "label": "Roasted Chicken",
+          "image": "https://www.edamam.com/web-img/530/53086a28442e65f61bd8e68abd7f58f7.jpg",
+          "source": "Food52",
+          "url": "https://food52.com/recipes/4527-roasted-chicken",
+          "shareAs": "http://www.edamam.com/recipe/roasted-chicken-3b7cb2359876b5b27920156479e3286f/chicken",
+          "yield": 2.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites",
+            "FODMAP"
+          ],
+          "ingredientLines": [
+            "1 whole chicken (3-4 lbs.)",
+            "3-4 carrots, peeled and sliced",
+            "3 celery ribs, sliced",
+            "1 onion, roughly chopped",
+            "3 tablespoons olive oil",
+            "2 teaspoons dried thyme",
+            "2 teaspoons herbs de provence",
+            "1 teaspoon dried sage",
+            "Salt and pepper",
+            "2 cups chicken stock",
+            "5 sliced wheat bread, cubed"
+          ],
+          "ingredients": [
+            {
+              "text": "1 whole chicken (3-4 lbs.)",
+              "weight": 1587.5732950000001
+            },
+            {
+              "text": "3-4 carrots, peeled and sliced",
+              "weight": 213.5
+            },
+            {
+              "text": "3 celery ribs, sliced",
+              "weight": 120.0
+            },
+            {
+              "text": "1 onion, roughly chopped",
+              "weight": 125.0
+            },
+            {
+              "text": "3 tablespoons olive oil",
+              "weight": 40.5
+            },
+            {
+              "text": "2 teaspoons dried thyme",
+              "weight": 2.0
+            },
+            {
+              "text": "2 teaspoons herbs de provence",
+              "weight": 2.0
+            },
+            {
+              "text": "1 teaspoon dried sage",
+              "weight": 0.7
+            },
+            {
+              "text": "Salt and pepper",
+              "weight": 26.947639770000002
+            },
+            {
+              "text": "Salt and pepper",
+              "weight": 13.473819885000001
+            },
+            {
+              "text": "2 cups chicken stock",
+              "weight": 480.0
+            },
+            {
+              "text": "5 sliced wheat bread, cubed",
+              "weight": 1920.0
+            }
+          ],
+          "calories": 8182.051445201349,
+          "totalWeight": 4504.747114885,
+          "totalTime": 176.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 8182.051445201349,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 272.71530252261095,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 69.1078987026592,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 1.5463633453819998,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 111.57711658239015,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 69.4947085738323,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 998.8915178164574,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 91.993976430905,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 138.25050244726398,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 424.74356023765154,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 824.06238045,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 11449.781652397,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 2981.21350455655,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 1185.2662001233498,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 7339.971265005651,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 85.55089647623349,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 38.9834413684915,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 4747.0789011003,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 2269.843366014951,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 49.866097449600005,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 9.0476896298358,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 6.829604684513,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 191.94673542049154,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 6.81589325796535,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 2112.2565398164497,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 1459.45653981645,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 384.0,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 3.34660450586,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 107.95498406,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 15.092187248603999,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 302.094390760745,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 409.10257226006746,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 419.5620038809399,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 345.53949351329595,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 332.9638392721524,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 367.9759057236199,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 849.4871204753031,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 274.68746015,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 477.0742355165416,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 298.12135045565503,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 282.2062381246071,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 156.16960138309895,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 475.28275820129716,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 354.3949215317409,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 678.1541287286142,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 252.20481844610563,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 55.406774944,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 753.97413581965,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 525.354206501,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 1199.667096378072,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 524.29948138195,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 528.0641349541124,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 139.44185441083332,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 719.6998937333334,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 100.61458165735999,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 251.74532563395417,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 272.71530252261095,
+              "hasRDI": true,
+              "daily": 419.5620038809399,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 69.1078987026592,
+                  "hasRDI": true,
+                  "daily": 345.53949351329595,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 1.5463633453819998,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 111.57711658239015,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 69.4947085738323,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 998.8915178164574,
+              "hasRDI": true,
+              "daily": 332.9638392721524,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 906.8975413855524,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 91.993976430905,
+                  "hasRDI": true,
+                  "daily": 367.9759057236199,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 138.25050244726398,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 424.74356023765154,
+              "hasRDI": true,
+              "daily": 849.4871204753031,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 824.06238045,
+              "hasRDI": true,
+              "daily": 274.68746015,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 11449.781652397,
+              "hasRDI": true,
+              "daily": 477.0742355165416,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 2981.21350455655,
+              "hasRDI": true,
+              "daily": 298.12135045565503,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 1185.2662001233498,
+              "hasRDI": true,
+              "daily": 282.2062381246071,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 7339.971265005651,
+              "hasRDI": true,
+              "daily": 156.16960138309895,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 85.55089647623349,
+              "hasRDI": true,
+              "daily": 475.28275820129716,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 38.9834413684915,
+              "hasRDI": true,
+              "daily": 354.3949215317409,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 4747.0789011003,
+              "hasRDI": true,
+              "daily": 678.1541287286142,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 2269.843366014951,
+              "hasRDI": true,
+              "daily": 252.20481844610563,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 49.866097449600005,
+              "hasRDI": true,
+              "daily": 55.406774944,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 9.0476896298358,
+              "hasRDI": true,
+              "daily": 753.97413581965,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 6.829604684513,
+              "hasRDI": true,
+              "daily": 525.354206501,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 191.94673542049154,
+              "hasRDI": true,
+              "daily": 1199.667096378072,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 6.81589325796535,
+              "hasRDI": true,
+              "daily": 524.29948138195,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 2112.2565398164497,
+              "hasRDI": true,
+              "daily": 528.0641349541124,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 1459.45653981645,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 384.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 3.34660450586,
+              "hasRDI": true,
+              "daily": 139.44185441083332,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 107.95498406,
+              "hasRDI": true,
+              "daily": 719.6998937333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 15.092187248603999,
+              "hasRDI": true,
+              "daily": 100.61458165735999,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 302.094390760745,
+              "hasRDI": true,
+              "daily": 251.74532563395417,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_b550f7f1182bc4d97f5473bcf15cf006",
+          "label": "Chicken cacciatore",
+          "image": "https://www.edamam.com/web-img/2ca/2ca946a40338e9b93c1d14dec518e1b8.jpg",
+          "source": "BBC",
+          "url": "http://www.bbc.co.uk/food/recipes/chickenalocacciatore_70349",
+          "shareAs": "http://www.edamam.com/recipe/chicken-cacciatore-b550f7f1182bc4d97f5473bcf15cf006/chicken",
+          "yield": 6.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Peanut-Free",
+            "Tree-Nut-Free"
+          ],
+          "cautions": [
+            "Sulfites",
+            "FODMAP"
+          ],
+          "ingredientLines": [
+            "8 tbsp olive oil",
+            "1 onion, sliced",
+            "2 celery stalks, roughly chopped",
+            "2 medium carrots, roughly chopped",
+            "6 chicken breasts, or chicken thighs, bones removed",
+            "175ml/6fl oz white wine",
+            "3 tbsp tomato purée",
+            "500ml/17 fl oz chicken stock",
+            "2 bay leaves",
+            "2-3 sage leaves",
+            "1 rosemary sprig",
+            "250g/9oz easy-cook polenta",
+            "Knob of butter",
+            "25g/1oz parmesan"
+          ],
+          "ingredients": [
+            {
+              "text": "8 tbsp olive oil",
+              "weight": 108.0
+            },
+            {
+              "text": "1 onion, sliced",
+              "weight": 125.0
+            },
+            {
+              "text": "2 celery stalks, roughly chopped",
+              "weight": 80.0
+            },
+            {
+              "text": "2 medium carrots, roughly chopped",
+              "weight": 122.0
+            },
+            {
+              "text": "6 chicken breasts, or chicken thighs, bones removed",
+              "weight": 1044.0
+            },
+            {
+              "text": "175ml/6fl oz white wine",
+              "weight": 173.97314680098222
+            },
+            {
+              "text": "3 tbsp tomato purée",
+              "weight": 42.599999999999994
+            },
+            {
+              "text": "500ml/17 fl oz chicken stock",
+              "weight": 507.21034052764503
+            },
+            {
+              "text": "2 bay leaves",
+              "weight": 1.2
+            },
+            {
+              "text": "2-3 sage leaves",
+              "weight": 2.5
+            },
+            {
+              "text": "1 rosemary sprig",
+              "weight": 5.0
+            },
+            {
+              "text": "250g/9oz easy-cook polenta",
+              "weight": 250.0
+            },
+            {
+              "text": "Knob of butter",
+              "weight": 28.4
+            },
+            {
+              "text": "25g/1oz parmesan",
+              "weight": 25.0
+            }
+          ],
+          "calories": 4446.914702966757,
+          "totalWeight": 2514.8834873286273,
+          "totalTime": 60.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 4446.914702966757,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 245.90941408633174,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 64.04548719309375,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 2.0271519999999996,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 130.6560361818709,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 36.37591802532388,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 254.1718968374514,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 19.4085,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 27.998055589626222,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 261.81419178405736,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 761.4363102158293,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 1992.7804442945815,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 639.7618934279178,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 451.403728301204,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 4311.003791782724,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 15.719749211470706,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 12.56664225289988,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 2531.3509583666414,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 1588.5071034052762,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 26.31962068105529,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.412640276524725,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.7555947614686456,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 116.57479279250295,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 6.954576881122355,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 242.19024849439202,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 242.19024849439202,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 3.89788,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 188.82999999999998,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 21.248543102158294,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 154.30361326825923,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 222.34573514833787,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 378.32217551743344,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 320.22743596546877,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 84.72396561248381,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 77.634,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 523.6283835681147,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 253.81210340527642,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 83.03251851227424,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 63.976189342791784,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 107.47707816695333,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 91.72348493154732,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 87.33194006372614,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 114.24220229908983,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 361.6215654809488,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 176.5007892672529,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 29.244022978950323,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 117.72002304372708,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 135.04575088220352,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 728.5924549531434,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 534.9674523940273,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 60.547562123598006,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 162.41166666666666,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 1258.8666666666666,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 141.65695401438862,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 128.58634439021603,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 245.90941408633174,
+              "hasRDI": true,
+              "daily": 378.32217551743344,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 64.04548719309375,
+                  "hasRDI": true,
+                  "daily": 320.22743596546877,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 2.0271519999999996,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 130.6560361818709,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 36.37591802532388,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 254.1718968374514,
+              "hasRDI": true,
+              "daily": 84.72396561248381,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 234.7633968374514,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 19.4085,
+                  "hasRDI": true,
+                  "daily": 77.634,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 27.998055589626222,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 261.81419178405736,
+              "hasRDI": true,
+              "daily": 523.6283835681147,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 761.4363102158293,
+              "hasRDI": true,
+              "daily": 253.81210340527642,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 1992.7804442945815,
+              "hasRDI": true,
+              "daily": 83.03251851227424,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 639.7618934279178,
+              "hasRDI": true,
+              "daily": 63.976189342791784,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 451.403728301204,
+              "hasRDI": true,
+              "daily": 107.47707816695333,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 4311.003791782724,
+              "hasRDI": true,
+              "daily": 91.72348493154732,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 15.719749211470706,
+              "hasRDI": true,
+              "daily": 87.33194006372614,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 12.56664225289988,
+              "hasRDI": true,
+              "daily": 114.24220229908983,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 2531.3509583666414,
+              "hasRDI": true,
+              "daily": 361.6215654809488,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 1588.5071034052762,
+              "hasRDI": true,
+              "daily": 176.5007892672529,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 26.31962068105529,
+              "hasRDI": true,
+              "daily": 29.244022978950323,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.412640276524725,
+              "hasRDI": true,
+              "daily": 117.72002304372708,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.7555947614686456,
+              "hasRDI": true,
+              "daily": 135.04575088220352,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 116.57479279250295,
+              "hasRDI": true,
+              "daily": 728.5924549531434,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 6.954576881122355,
+              "hasRDI": true,
+              "daily": 534.9674523940273,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 242.19024849439202,
+              "hasRDI": true,
+              "daily": 60.547562123598006,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 242.19024849439202,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 3.89788,
+              "hasRDI": true,
+              "daily": 162.41166666666666,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 188.82999999999998,
+              "hasRDI": true,
+              "daily": 1258.8666666666666,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 21.248543102158294,
+              "hasRDI": true,
+              "daily": 141.65695401438862,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 154.30361326825923,
+              "hasRDI": true,
+              "daily": 128.58634439021603,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_71ab1bfee5b89e904185ef03c337d52b",
+          "label": "Tarragon Chicken",
+          "image": "https://www.edamam.com/web-img/b28/b28acc0eed7e65de535d36954006f358.jpg",
+          "source": "French Revolution Food",
+          "url": "http://www.frenchrevolutionfood.com/2009/09/french-in-a-flash-tarragon-chicken-and-carrot-muffins-with-sweet-chevre-icing/",
+          "shareAs": "http://www.edamam.com/recipe/tarragon-chicken-71ab1bfee5b89e904185ef03c337d52b/chicken",
+          "yield": 4.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Peanut-Free",
+            "Tree-Nut-Free"
+          ],
+          "cautions": [
+            "Gluten",
+            "Wheat",
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "8 vine ripened tomatoes, peeled, seeded, and finely diced",
+            "8 chicken legs",
+            "8 chicken thighs",
+            "2 tablespoons olive oil, plus 1 tablespoon",
+            "4 shallots, roughly chopped",
+            "2 cloves garlic, smashed",
+            "1/3 cup dry vermouth",
+            "1/3 cup dry white wine",
+            "1 cup low-sodium chicken stock",
+            "6 stems tarragon"
+          ],
+          "ingredients": [
+            {
+              "text": "8 vine ripened tomatoes, peeled, seeded, and finely diced",
+              "weight": 984.0
+            },
+            {
+              "text": "8 chicken legs",
+              "weight": 2752.0
+            },
+            {
+              "text": "8 chicken thighs",
+              "weight": 1192.0
+            },
+            {
+              "text": "2 tablespoons olive oil, plus 1 tablespoon",
+              "weight": 27.0
+            },
+            {
+              "text": "2 tablespoons olive oil, plus 1 tablespoon",
+              "weight": 13.5
+            },
+            {
+              "text": "4 shallots, roughly chopped",
+              "weight": 236.44444444444446
+            },
+            {
+              "text": "2 cloves garlic, smashed",
+              "weight": 6.0
+            },
+            {
+              "text": "1/3 cup dry vermouth",
+              "weight": 78.66666666666666
+            },
+            {
+              "text": "1/3 cup dry white wine",
+              "weight": 75.33333333333333
+            },
+            {
+              "text": "1 cup low-sodium chicken stock",
+              "weight": 240.0
+            },
+            {
+              "text": "6 stems tarragon",
+              "weight": 10.8
+            }
+          ],
+          "calories": 9435.246666666666,
+          "totalWeight": 5615.7444444444445,
+          "totalTime": 211.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 9435.246666666666,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 681.8915644444445,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 180.62444355555553,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 2.6644,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 295.4764792222222,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 139.4611523333333,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 100.04442666666668,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 20.299422222222223,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 46.20404444444444,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 669.7396711111112,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 3727.5200000000004,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3442.999333333333,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 673.9547777777778,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 952.896,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 11828.436111111108,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 37.40419999999999,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 59.37324444444445,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 6659.344000000002,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 1480.68,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 166.49955555555553,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 3.431874666666666,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 6.095574222222222,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 196.2085555555555,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 14.92906,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 405.1431111111111,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 405.1431111111111,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 23.0416,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 90.8,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 19.782327777777777,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 192.73988888888888,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 471.7623333333333,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 1049.0639452991454,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 903.1222177777776,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 33.34814222222223,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 81.19768888888889,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 1339.4793422222224,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 1242.506666666667,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 143.45830555555557,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 67.39547777777778,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 226.87999999999997,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 251.6688534278959,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 207.80111111111103,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 539.7567676767677,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 951.3348571428573,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 164.52,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 184.99950617283946,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 285.9895555555555,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 468.8903247863247,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 1226.303472222222,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 1148.3892307692306,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 101.28577777777778,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 960.0666666666666,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 605.3333333333334,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 131.8821851851852,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 160.61657407407407,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 681.8915644444445,
+              "hasRDI": true,
+              "daily": 1049.0639452991454,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 180.62444355555553,
+                  "hasRDI": true,
+                  "daily": 903.1222177777776,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 2.6644,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 295.4764792222222,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 139.4611523333333,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 100.04442666666668,
+              "hasRDI": true,
+              "daily": 33.34814222222223,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 79.74500444444446,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 20.299422222222223,
+                  "hasRDI": true,
+                  "daily": 81.19768888888889,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 46.20404444444444,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 669.7396711111112,
+              "hasRDI": true,
+              "daily": 1339.4793422222224,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 3727.5200000000004,
+              "hasRDI": true,
+              "daily": 1242.506666666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3442.999333333333,
+              "hasRDI": true,
+              "daily": 143.45830555555557,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 673.9547777777778,
+              "hasRDI": true,
+              "daily": 67.39547777777778,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 952.896,
+              "hasRDI": true,
+              "daily": 226.87999999999997,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 11828.436111111108,
+              "hasRDI": true,
+              "daily": 251.6688534278959,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 37.40419999999999,
+              "hasRDI": true,
+              "daily": 207.80111111111103,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 59.37324444444445,
+              "hasRDI": true,
+              "daily": 539.7567676767677,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 6659.344000000002,
+              "hasRDI": true,
+              "daily": 951.3348571428573,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 1480.68,
+              "hasRDI": true,
+              "daily": 164.52,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 166.49955555555553,
+              "hasRDI": true,
+              "daily": 184.99950617283946,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 3.431874666666666,
+              "hasRDI": true,
+              "daily": 285.9895555555555,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 6.095574222222222,
+              "hasRDI": true,
+              "daily": 468.8903247863247,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 196.2085555555555,
+              "hasRDI": true,
+              "daily": 1226.303472222222,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 14.92906,
+              "hasRDI": true,
+              "daily": 1148.3892307692306,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 405.1431111111111,
+              "hasRDI": true,
+              "daily": 101.28577777777778,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 405.1431111111111,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 23.0416,
+              "hasRDI": true,
+              "daily": 960.0666666666666,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 90.8,
+              "hasRDI": true,
+              "daily": 605.3333333333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 19.782327777777777,
+              "hasRDI": true,
+              "daily": 131.8821851851852,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 192.73988888888888,
+              "hasRDI": true,
+              "daily": 160.61657407407407,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_63f409a7fbec68dbd88e6240c85d81b4",
+          "label": "Chicken Soup",
+          "image": "https://www.edamam.com/web-img/e20/e20d522d53088284fc5a31f365cbdebd.jpg",
+          "source": "Cookstr",
+          "url": "http://www.cookstr.com/recipes/chicken-soup-3-sharon-lebewohl",
+          "shareAs": "http://www.edamam.com/recipe/chicken-soup-63f409a7fbec68dbd88e6240c85d81b4/chicken",
+          "yield": 8.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "FODMAP"
+          ],
+          "ingredientLines": [
+            "1 pound chicken parts",
+            "2 stalks celery, including leafy tops, cut into 3-inch pieces",
+            "1 whole chicken, thoroughly rinsed",
+            "Salt to rub inside the chicken",
+            "1 large whole onion, unpeeled (find one with a firm, golden-brown peel)",
+            "1 large whole carrot, peeled",
+            "1 medium parsnip, peeled",
+            "2 teaspoons salt",
+            "¼ teaspoon pepper",
+            "1 bunch dill, cleaned and tied with a string"
+          ],
+          "ingredients": [
+            {
+              "text": "1 pound chicken parts",
+              "weight": 453.59237
+            },
+            {
+              "text": "2 stalks celery, including leafy tops, cut into 3-inch pieces",
+              "weight": 80.0
+            },
+            {
+              "text": "1 whole chicken, thoroughly rinsed",
+              "weight": 920.0
+            },
+            {
+              "text": "Salt to rub inside the chicken",
+              "weight": 10.94230422
+            },
+            {
+              "text": "1 large whole onion, unpeeled (find one with a firm, golden-brown peel)",
+              "weight": 150.0
+            },
+            {
+              "text": "1 large whole carrot, peeled",
+              "weight": 72.0
+            },
+            {
+              "text": "1 medium parsnip, peeled",
+              "weight": 133.0
+            },
+            {
+              "text": "2 teaspoons salt",
+              "weight": 12.0
+            },
+            {
+              "text": "¼ teaspoon pepper",
+              "weight": 0.725
+            },
+            {
+              "text": "1 bunch dill, cleaned and tied with a string",
+              "weight": 2.4
+            }
+          ],
+          "calories": 3185.3608877000006,
+          "totalWeight": 1819.630868348438,
+          "totalTime": 120.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 3185.3608877000006,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 214.80200765700005,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 60.37379081880001,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 1.2779535145,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 89.11605622800002,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 45.68701296790001,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 48.976398425,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 12.596825,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 17.233439999999998,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 250.67942702400006,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 1134.5205226000003,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 4213.112509587602,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 281.19445550362514,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 339.2955115834844,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 3848.2587646678753,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 13.094800160549848,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 19.258222571348437,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 2249.5995209,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 1109.7859951,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 57.198,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.1383174301,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.9644779365,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 85.6625738625,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 5.2587752738999995,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 232.6210211,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 232.6210211,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 5.664272694000001,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 105.60777110000001,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 6.4229839769999995,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 87.98126477,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 159.26804438500002,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 330.4646271646154,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 301.86895409400006,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 16.325466141666666,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 50.3873,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 501.3588540480001,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 378.1735075333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 175.5463545661501,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 28.119445550362514,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 80.78464561511534,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 81.8778460567633,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 72.74888978083249,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 175.07475064862217,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 321.3713601285714,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 123.30955501111112,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 63.553333333333335,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 94.85978584166668,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 151.11368742307693,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 535.391086640625,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 404.52117491538456,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 58.155255275,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 236.01136225000005,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 704.0518073333334,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 42.819893179999994,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 73.31772064166667,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 214.80200765700005,
+              "hasRDI": true,
+              "daily": 330.4646271646154,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 60.37379081880001,
+                  "hasRDI": true,
+                  "daily": 301.86895409400006,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 1.2779535145,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 89.11605622800002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 45.68701296790001,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 48.976398425,
+              "hasRDI": true,
+              "daily": 16.325466141666666,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 36.379573425,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 12.596825,
+                  "hasRDI": true,
+                  "daily": 50.3873,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 17.233439999999998,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 250.67942702400006,
+              "hasRDI": true,
+              "daily": 501.3588540480001,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 1134.5205226000003,
+              "hasRDI": true,
+              "daily": 378.1735075333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 4213.112509587602,
+              "hasRDI": true,
+              "daily": 175.5463545661501,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 281.19445550362514,
+              "hasRDI": true,
+              "daily": 28.119445550362514,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 339.2955115834844,
+              "hasRDI": true,
+              "daily": 80.78464561511534,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 3848.2587646678753,
+              "hasRDI": true,
+              "daily": 81.8778460567633,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 13.094800160549848,
+              "hasRDI": true,
+              "daily": 72.74888978083249,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 19.258222571348437,
+              "hasRDI": true,
+              "daily": 175.07475064862217,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 2249.5995209,
+              "hasRDI": true,
+              "daily": 321.3713601285714,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 1109.7859951,
+              "hasRDI": true,
+              "daily": 123.30955501111112,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 57.198,
+              "hasRDI": true,
+              "daily": 63.553333333333335,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.1383174301,
+              "hasRDI": true,
+              "daily": 94.85978584166668,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.9644779365,
+              "hasRDI": true,
+              "daily": 151.11368742307693,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 85.6625738625,
+              "hasRDI": true,
+              "daily": 535.391086640625,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 5.2587752738999995,
+              "hasRDI": true,
+              "daily": 404.52117491538456,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 232.6210211,
+              "hasRDI": true,
+              "daily": 58.155255275,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 232.6210211,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 5.664272694000001,
+              "hasRDI": true,
+              "daily": 236.01136225000005,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 105.60777110000001,
+              "hasRDI": true,
+              "daily": 704.0518073333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 6.4229839769999995,
+              "hasRDI": true,
+              "daily": 42.819893179999994,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 87.98126477,
+              "hasRDI": true,
+              "daily": 73.31772064166667,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_2f0f56abdb4b8ee95fc08f6e4adb443c",
+          "label": "Chicken Saltimbocca",
+          "image": "https://www.edamam.com/web-img/36f/36f50faee795ad7c689c16afb606465d.jpg",
+          "source": "Cooking Channel",
+          "url": "http://www.cookingchanneltv.com/recipes/chicken-saltimbocca.html",
+          "shareAs": "http://www.edamam.com/recipe/chicken-saltimbocca-2f0f56abdb4b8ee95fc08f6e4adb443c/chicken",
+          "yield": 6.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Gluten",
+            "Wheat",
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "6 (3-ounce) chicken cutlets, pounded to evenly flatten",
+            "Salt and freshly ground black pepper",
+            "6 paper-thin slices prosciutto",
+            "1 (10-ounce) box frozen chopped spinach, thawed",
+            "3 tablespoons olive oil",
+            "1/4 cup grated parmesan",
+            "1 (14-ounce) can low-salt chicken broth",
+            "2 tablespoons fresh lemon juice"
+          ],
+          "ingredients": [
+            {
+              "text": "6 (3-ounce) chicken cutlets, pounded to evenly flatten",
+              "weight": 510.29141625
+            },
+            {
+              "text": "Salt and freshly ground black pepper",
+              "weight": 8.2645798275
+            },
+            {
+              "text": "Salt and freshly ground black pepper",
+              "weight": 4.13228991375
+            },
+            {
+              "text": "6 paper-thin slices prosciutto",
+              "weight": 90.0
+            },
+            {
+              "text": "1 (10-ounce) box frozen chopped spinach, thawed",
+              "weight": 283.49523125
+            },
+            {
+              "text": "3 tablespoons olive oil",
+              "weight": 40.5
+            },
+            {
+              "text": "1/4 cup grated parmesan",
+              "weight": 28.25
+            },
+            {
+              "text": "1 (14-ounce) can low-salt chicken broth",
+              "weight": 396.89332375000004
+            },
+            {
+              "text": "2 tablespoons fresh lemon juice",
+              "weight": 28.0
+            }
+          ],
+          "calories": 1491.6598714310128,
+          "totalWeight": 1381.56226116375,
+          "totalTime": 35.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 1491.6598714310128,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 96.73544379806326,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 24.546828858599405,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.42864478965,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 51.85365303326262,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 14.311899879626724,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 20.807846179218124,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 7.366364435678751,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 2.6646879475730003,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 136.80915824128866,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 343.47920512,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3416.35256158525,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 705.3127008354124,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 373.6646649275125,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 3390.4976743537377,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 13.418217281575126,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 8.534332363348625,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1459.330329921225,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 1487.1618047592126,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 90.49815998125,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.0108135272718501,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.3251002690822502,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 51.57985240097916,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 3.184753101861513,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 579.0900632303375,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 579.0900632303375,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 2.91588597595,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 103.98480128000003,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 13.068058468578,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 1400.624280295059,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 74.58299357155065,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 148.82375968932809,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 122.73414429299703,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 6.935948726406041,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 29.465457742715003,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 273.6183164825773,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 114.49306837333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 142.34802339938543,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 70.53127008354124,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 88.96777736369346,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 72.13824839050507,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 74.54565156430625,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 77.58483966680568,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 208.47576141731784,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 165.24020052880138,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 100.55351109027777,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 84.23446060598752,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 101.93078992940387,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 322.37407750611976,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 244.981007835501,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 144.77251580758437,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 121.49524899791668,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 693.2320085333336,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 87.12038979052,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 1167.1869002458823,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 96.73544379806326,
+              "hasRDI": true,
+              "daily": 148.82375968932809,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 24.546828858599405,
+                  "hasRDI": true,
+                  "daily": 122.73414429299703,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.42864478965,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 51.85365303326262,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 14.311899879626724,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 20.807846179218124,
+              "hasRDI": true,
+              "daily": 6.935948726406041,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 13.441481743539374,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 7.366364435678751,
+                  "hasRDI": true,
+                  "daily": 29.465457742715003,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 2.6646879475730003,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 136.80915824128866,
+              "hasRDI": true,
+              "daily": 273.6183164825773,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 343.47920512,
+              "hasRDI": true,
+              "daily": 114.49306837333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3416.35256158525,
+              "hasRDI": true,
+              "daily": 142.34802339938543,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 705.3127008354124,
+              "hasRDI": true,
+              "daily": 70.53127008354124,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 373.6646649275125,
+              "hasRDI": true,
+              "daily": 88.96777736369346,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 3390.4976743537377,
+              "hasRDI": true,
+              "daily": 72.13824839050507,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 13.418217281575126,
+              "hasRDI": true,
+              "daily": 74.54565156430625,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 8.534332363348625,
+              "hasRDI": true,
+              "daily": 77.58483966680568,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1459.330329921225,
+              "hasRDI": true,
+              "daily": 208.47576141731784,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 1487.1618047592126,
+              "hasRDI": true,
+              "daily": 165.24020052880138,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 90.49815998125,
+              "hasRDI": true,
+              "daily": 100.55351109027777,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.0108135272718501,
+              "hasRDI": true,
+              "daily": 84.23446060598752,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.3251002690822502,
+              "hasRDI": true,
+              "daily": 101.93078992940387,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 51.57985240097916,
+              "hasRDI": true,
+              "daily": 322.37407750611976,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 3.184753101861513,
+              "hasRDI": true,
+              "daily": 244.981007835501,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 579.0900632303375,
+              "hasRDI": true,
+              "daily": 144.77251580758437,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 579.0900632303375,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 2.91588597595,
+              "hasRDI": true,
+              "daily": 121.49524899791668,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 103.98480128000003,
+              "hasRDI": true,
+              "daily": 693.2320085333336,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 13.068058468578,
+              "hasRDI": true,
+              "daily": 87.12038979052,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 1400.624280295059,
+              "hasRDI": true,
+              "daily": 1167.1869002458823,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_12fafbb01eadad8203145452e7ddc885",
+          "label": "Easy Chicken Stock",
+          "image": "https://www.edamam.com/web-img/2fe/2fe1ba60ec3448742e895cd495c3d843.jpg",
+          "source": "My Recipes",
+          "url": "http://www.myrecipes.com/recipe/easy-chicken-stock",
+          "shareAs": "http://www.edamam.com/recipe/easy-chicken-stock-12fafbb01eadad8203145452e7ddc885/chicken",
+          "yield": 10.0,
+          "dietLabels": [
+            "Low-Carb"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "2 pounds  chicken wings",
+            "2   (32-oz.) containers chicken broth"
+          ],
+          "ingredients": [
+            {
+              "text": "2 pounds  chicken wings",
+              "weight": 907.18474
+            },
+            {
+              "text": "2   (32-oz.) containers chicken broth",
+              "weight": 1814.36948
+            }
+          ],
+          "calories": 2385.8958662000005,
+          "totalWeight": 2721.55422,
+          "totalTime": 90.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2385.8958662000005,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 141.15794554400003,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 42.66489832220001,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.6350293180000002,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 67.05909598080001,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 29.882665335600002,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 64.04724264400001,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 28.667037784000005,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 204.66087734400003,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 1061.4061458,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3356.5835380000003,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 154.2214058,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 217.7243376,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 3601.5234178000005,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 7.983225712000001,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 13.517052626000002,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1605.7169898000002,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 99.79032140000001,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 3.6287389600000006,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.1249090776000004,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 2.4766143402000003,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 80.42192720100002,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 5.8967008100000005,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 154.2214058,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 154.2214058,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 2.2679618500000003,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 45.35923700000001,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 6.35029318,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 38.10175908,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 119.29479331000002,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 217.16607006769235,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 213.32449161100004,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 21.349080881333336,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 409.32175468800006,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 353.80204860000003,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 139.85764741666668,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 15.42214058,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 51.839128,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 76.62815782553193,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 44.35125395555556,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 122.88229660000002,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 229.38814140000002,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 11.08781348888889,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 4.031932177777779,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 93.74242313333338,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 190.50879540000003,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 502.6370450062501,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 453.5923700000001,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 38.55535145,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 94.49841041666669,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 302.3949133333334,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 42.33528786666667,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 31.751465900000003,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 141.15794554400003,
+              "hasRDI": true,
+              "daily": 217.16607006769235,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 42.66489832220001,
+                  "hasRDI": true,
+                  "daily": 213.32449161100004,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.6350293180000002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 67.05909598080001,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 29.882665335600002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 64.04724264400001,
+              "hasRDI": true,
+              "daily": 21.349080881333336,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 64.04724264400001,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 28.667037784000005,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 204.66087734400003,
+              "hasRDI": true,
+              "daily": 409.32175468800006,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 1061.4061458,
+              "hasRDI": true,
+              "daily": 353.80204860000003,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3356.5835380000003,
+              "hasRDI": true,
+              "daily": 139.85764741666668,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 154.2214058,
+              "hasRDI": true,
+              "daily": 15.42214058,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 217.7243376,
+              "hasRDI": true,
+              "daily": 51.839128,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 3601.5234178000005,
+              "hasRDI": true,
+              "daily": 76.62815782553193,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 7.983225712000001,
+              "hasRDI": true,
+              "daily": 44.35125395555556,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 13.517052626000002,
+              "hasRDI": true,
+              "daily": 122.88229660000002,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1605.7169898000002,
+              "hasRDI": true,
+              "daily": 229.38814140000002,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 99.79032140000001,
+              "hasRDI": true,
+              "daily": 11.08781348888889,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 3.6287389600000006,
+              "hasRDI": true,
+              "daily": 4.031932177777779,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.1249090776000004,
+              "hasRDI": true,
+              "daily": 93.74242313333338,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 2.4766143402000003,
+              "hasRDI": true,
+              "daily": 190.50879540000003,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 80.42192720100002,
+              "hasRDI": true,
+              "daily": 502.6370450062501,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 5.8967008100000005,
+              "hasRDI": true,
+              "daily": 453.5923700000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 154.2214058,
+              "hasRDI": true,
+              "daily": 38.55535145,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 154.2214058,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 2.2679618500000003,
+              "hasRDI": true,
+              "daily": 94.49841041666669,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 45.35923700000001,
+              "hasRDI": true,
+              "daily": 302.3949133333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 6.35029318,
+              "hasRDI": true,
+              "daily": 42.33528786666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 38.10175908,
+              "hasRDI": true,
+              "daily": 31.751465900000003,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      }
     ]
-  },
-  "more": true,
-  "count": 91409,
-  "hits": [
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_b79327d05b8e5b838ad6cfd9576b30b6",
-        "label": "checking to see if this works",
-        "image": "https://www.edamam.com/web-img/e42/e42f9119813e890af34c259785ae1cfb.jpg",
-        "source": "Serious Eats",
-        "url": "http://www.seriouseats.com/recipes/2011/12/chicken-vesuvio-recipe.html",
-        "shareAs": "http://www.edamam.com/recipe/chicken-vesuvio-b79327d05b8e5b838ad6cfd9576b30b6/chicken",
-        "yield": 4.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Peanut-Free",
-          "Tree-Nut-Free"
-        ],
-        "cautions": [
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "1/2 cup olive oil",
-          "5 cloves garlic, peeled",
-          "2 large russet potatoes, peeled and cut into chunks",
-          "1 3-4 pound chicken, cut into 8 pieces (or 3 pound chicken legs)",
-          "3/4 cup white wine",
-          "3/4 cup chicken stock",
-          "3 tablespoons chopped parsley",
-          "1 tablespoon dried oregano",
-          "Salt and pepper",
-          "1 cup frozen peas, thawed"
-        ],
-        "ingredients": [
-          {
-            "text": "1/2 cup olive oil",
-            "weight": 108.0
-          },
-          {
-            "text": "5 cloves garlic, peeled",
-            "weight": 15.0
-          },
-          {
-            "text": "2 large russet potatoes, peeled and cut into chunks",
-            "weight": 738.0
-          },
-          {
-            "text": "1 3-4 pound chicken, cut into 8 pieces (or 3 pound chicken legs)",
-            "weight": 1587.5732950000001
-          },
-          {
-            "text": "3/4 cup white wine",
-            "weight": 169.5
-          },
-          {
-            "text": "3/4 cup chicken stock",
-            "weight": 180.0
-          },
-          {
-            "text": "3 tablespoons chopped parsley",
-            "weight": 11.399999999999999
-          },
-          {
-            "text": "1 tablespoon dried oregano",
-            "weight": 5.9999999998985585
-          },
-          {
-            "text": "Salt and pepper",
-            "weight": 17.696839769999393
-          },
-          {
-            "text": "Salt and pepper",
-            "weight": 8.848419884999696
-          },
-          {
-            "text": "1 cup frozen peas, thawed",
-            "weight": 134.0
-          }
-        ],
-        "calories": 4230.305691201081,
-        "totalWeight": 2972.9302457924105,
-        "totalTime": 60.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 4230.305691201081,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 274.57692448260667,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 62.54398613465762,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 1.047163345382,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 147.41199987638942,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 47.3914730818309,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 177.8427845163874,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 21.103850230861813,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 16.29572988725985,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 230.99085117764236,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 815.06238045,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 6879.517981530534,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 447.3120299727316,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 485.56685143215077,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 5950.924381476969,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 23.630588288190932,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 18.41378763939628,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 2234.2507691001497,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 637.9185080148637,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 103.79879744959767,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 1.73140519783562,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 1.926703964512464,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 87.03578409848684,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 6.914193343964289,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 283.3102218162095,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 283.3102218162095,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 3.34660450586,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 107.95498406,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 20.17637308858548,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 371.9191109601138,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 211.51528456005406,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 422.42603766554873,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 312.7199306732881,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 59.28092817212914,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 84.41540092344725,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 461.9817023552847,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 271.68746015,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 286.64658256377226,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 44.73120299727315,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 115.61115510289305,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 126.61541237185041,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 131.28104604550518,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 167.3980694490571,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 319.17868130002137,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 70.87983422387376,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 115.33199716621964,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 144.28376648630166,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 148.20799727018954,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 543.9736506155427,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 531.8610264587915,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 70.82755545405237,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 139.44185441083332,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 719.6998937333334,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 134.5091539239032,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 309.93259246676155,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 274.57692448260667,
-            "hasRDI": true,
-            "daily": 422.42603766554873,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 62.54398613465762,
-                "hasRDI": true,
-                "daily": 312.7199306732881,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 1.047163345382,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 147.41199987638942,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 47.3914730818309,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 177.8427845163874,
-            "hasRDI": true,
-            "daily": 59.28092817212914,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 156.7389342855256,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 21.103850230861813,
-                "hasRDI": true,
-                "daily": 84.41540092344725,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 16.29572988725985,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 230.99085117764236,
-            "hasRDI": true,
-            "daily": 461.9817023552847,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 815.06238045,
-            "hasRDI": true,
-            "daily": 271.68746015,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 6879.517981530534,
-            "hasRDI": true,
-            "daily": 286.64658256377226,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 447.3120299727316,
-            "hasRDI": true,
-            "daily": 44.73120299727315,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 485.56685143215077,
-            "hasRDI": true,
-            "daily": 115.61115510289305,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 5950.924381476969,
-            "hasRDI": true,
-            "daily": 126.61541237185041,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 23.630588288190932,
-            "hasRDI": true,
-            "daily": 131.28104604550518,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 18.41378763939628,
-            "hasRDI": true,
-            "daily": 167.3980694490571,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 2234.2507691001497,
-            "hasRDI": true,
-            "daily": 319.17868130002137,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 637.9185080148637,
-            "hasRDI": true,
-            "daily": 70.87983422387376,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 103.79879744959767,
-            "hasRDI": true,
-            "daily": 115.33199716621964,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 1.73140519783562,
-            "hasRDI": true,
-            "daily": 144.28376648630166,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 1.926703964512464,
-            "hasRDI": true,
-            "daily": 148.20799727018954,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 87.03578409848684,
-            "hasRDI": true,
-            "daily": 543.9736506155427,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 6.914193343964289,
-            "hasRDI": true,
-            "daily": 531.8610264587915,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 283.3102218162095,
-            "hasRDI": true,
-            "daily": 70.82755545405237,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 283.3102218162095,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 3.34660450586,
-            "hasRDI": true,
-            "daily": 139.44185441083332,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 107.95498406,
-            "hasRDI": true,
-            "daily": 719.6998937333334,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 20.17637308858548,
-            "hasRDI": true,
-            "daily": 134.5091539239032,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 371.9191109601138,
-            "hasRDI": true,
-            "daily": 309.93259246676155,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_584ac5e486c088b3c8409c252d7f290c",
-        "label": "Chicken Gravy",
-        "image": "https://www.edamam.com/web-img/fd1/fd1afed1849c44f5185720394e363b4e.jpg",
-        "source": "Martha Stewart",
-        "url": "http://www.marthastewart.com/332664/chicken-gravy",
-        "shareAs": "http://www.edamam.com/recipe/chicken-gravy-584ac5e486c088b3c8409c252d7f290c/chicken",
-        "yield": 6.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "Gluten",
-          "Wheat",
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "4 cups chicken bones and wings",
-          "2 tablespoons unsalted butter, softened",
-          "2 tablespoons all-purpose flour",
-          "4 cups homemade bruce and eric bromberg's chicken stock, or store-bought low-sodium chicken stock",
-          "1 tablespoon fresh thyme leaves",
-          "Coarse salt and freshly ground black pepper"
-        ],
-        "ingredients": [
-          {
-            "text": "4 cups chicken bones and wings",
-            "weight": 568.0
-          },
-          {
-            "text": "2 tablespoons unsalted butter, softened",
-            "weight": 28.4
-          },
-          {
-            "text": "2 tablespoons all-purpose flour",
-            "weight": 15.6
-          },
-          {
-            "text": "4 cups homemade bruce and eric bromberg's chicken stock, or store-bought low-sodium chicken stock",
-            "weight": 960.0
-          },
-          {
-            "text": "1 tablespoon fresh thyme leaves",
-            "weight": 7.499999999873198
-          },
-          {
-            "text": "Coarse salt and freshly ground black pepper",
-            "weight": 0.0
-          },
-          {
-            "text": "Coarse salt and freshly ground black pepper",
-            "weight": 4.738499999999619
-          }
-        ],
-        "calories": 1092.360634999871,
-        "totalWeight": 1584.2384999998728,
-        "totalTime": 270.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 1092.360634999871,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 68.98859509999785,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 33.47207691999941,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 0.9309519999999999,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 8.655028514999897,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 2.2254302299993216,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 28.305420749968757,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 2.670040499982152,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 1.3374863999999977,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 84.4422101499929,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 242.82,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 1116.6586999999886,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 98.92255499948476,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 33.702834999796465,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 957.7576649992228,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 11.898378349977836,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 1.2868981499977004,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 327.10082999986497,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 213.3853949996981,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 12.00749999979699,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 0.13259757999993874,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 0.418574299999402,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 14.275913054997684,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 0.14360503499955762,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 50.42854499994287,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 9.556544999942874,
-            "unit": "µg"
-          },
-          "FOLAC": {
-            "label": "Folic acid",
-            "quantity": 24.024,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 1.00828,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 17.04,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 0.7440403999999959,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 9.791724499999376,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 54.618031749993555,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 106.13630015384285,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 167.36038459999705,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 9.435140249989585,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 10.680161999928607,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 168.8844202999858,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 80.94,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 46.527445833332855,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 9.892255499948476,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 8.024484523761062,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 20.377822659557932,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 66.1021019443213,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 11.699074090888184,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 46.72868999998071,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 23.70948833329979,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 13.3416666664411,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 11.049798333328228,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 32.19802307687708,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 89.22445659373552,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 11.046541153812123,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 12.607136249985718,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 42.01166666666667,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 113.6,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 4.960269333333306,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 8.159770416666145,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 68.98859509999785,
-            "hasRDI": true,
-            "daily": 106.13630015384285,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 33.47207691999941,
-                "hasRDI": true,
-                "daily": 167.36038459999705,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 0.9309519999999999,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 8.655028514999897,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 2.2254302299993216,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 28.305420749968757,
-            "hasRDI": true,
-            "daily": 9.435140249989585,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 25.635380249986603,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 2.670040499982152,
-                "hasRDI": true,
-                "daily": 10.680161999928607,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 1.3374863999999977,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 84.4422101499929,
-            "hasRDI": true,
-            "daily": 168.8844202999858,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 242.82,
-            "hasRDI": true,
-            "daily": 80.94,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 1116.6586999999886,
-            "hasRDI": true,
-            "daily": 46.527445833332855,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 98.92255499948476,
-            "hasRDI": true,
-            "daily": 9.892255499948476,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 33.702834999796465,
-            "hasRDI": true,
-            "daily": 8.024484523761062,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 957.7576649992228,
-            "hasRDI": true,
-            "daily": 20.377822659557932,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 11.898378349977836,
-            "hasRDI": true,
-            "daily": 66.1021019443213,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 1.2868981499977004,
-            "hasRDI": true,
-            "daily": 11.699074090888184,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 327.10082999986497,
-            "hasRDI": true,
-            "daily": 46.72868999998071,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 213.3853949996981,
-            "hasRDI": true,
-            "daily": 23.70948833329979,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 12.00749999979699,
-            "hasRDI": true,
-            "daily": 13.3416666664411,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 0.13259757999993874,
-            "hasRDI": true,
-            "daily": 11.049798333328228,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 0.418574299999402,
-            "hasRDI": true,
-            "daily": 32.19802307687708,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 14.275913054997684,
-            "hasRDI": true,
-            "daily": 89.22445659373552,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 0.14360503499955762,
-            "hasRDI": true,
-            "daily": 11.046541153812123,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 50.42854499994287,
-            "hasRDI": true,
-            "daily": 12.607136249985718,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 9.556544999942874,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 24.024,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 1.00828,
-            "hasRDI": true,
-            "daily": 42.01166666666667,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 17.04,
-            "hasRDI": true,
-            "daily": 113.6,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 0.7440403999999959,
-            "hasRDI": true,
-            "daily": 4.960269333333306,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 9.791724499999376,
-            "hasRDI": true,
-            "daily": 8.159770416666145,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_1817e7fccea9ae39d09c0e2c7fb86cb2",
-        "label": "Kreplach (Chicken Dumplings)",
-        "image": "https://www.edamam.com/web-img/4dd/4dd1c7a0d8b00e8929bd6babf0968ba2.jpg",
-        "source": "Tasting Table",
-        "url": "https://www.tastingtable.com/entry_detail/chefs_recipes/10154/Matzo_balls_watch_your_back.htm",
-        "shareAs": "http://www.edamam.com/recipe/kreplach-chicken-dumplings-1817e7fccea9ae39d09c0e2c7fb86cb2/chicken",
-        "yield": 8.0,
-        "dietLabels": [
-          "Low-Fat"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "1½ teaspoons canola oil",
-          "½ small shallot, finely chopped",
-          "1 cup (about ½ pound) raw, boneless chicken meat (preferably from 3 boneless chicken thighs), roughly chopped",
-          "⅔ cup (about ¼ pound) chicken skin and fat (reserved from the 3 chicken thighs)",
-          "2 chicken livers (optional)",
-          "2 garlic cloves, finely chopped",
-          "¼ cup finely chopped chives, plus extra for serving",
-          "1¼ teaspoons kosher salt",
-          "¾ teaspoon freshly ground black pepper",
-          "30 to 34 square wonton wrappers",
-          "8 cups store-bought or homemade chicken broth"
-        ],
-        "ingredients": [
-          {
-            "text": "1½ teaspoons canola oil",
-            "weight": 6.75
-          },
-          {
-            "text": "½ small shallot, finely chopped",
-            "weight": 20.0
-          },
-          {
-            "text": "1 cup (about ½ pound) raw, boneless chicken meat (preferably from 3 boneless chicken thighs), roughly chopped",
-            "weight": 226.796185
-          },
-          {
-            "text": "⅔ cup (about ¼ pound) chicken skin and fat (reserved from the 3 chicken thighs)",
-            "weight": 113.3980925
-          },
-          {
-            "text": "2 garlic cloves, finely chopped",
-            "weight": 6.0
-          },
-          {
-            "text": "1¼ teaspoons kosher salt",
-            "weight": 6.067708333641094
-          },
-          {
-            "text": "¾ teaspoon freshly ground black pepper",
-            "weight": 1.7249999999999999
-          },
-          {
-            "text": "30 to 34 square wonton wrappers",
-            "weight": 1024.0
-          },
-          {
-            "text": "8 cups store-bought or homemade chicken broth",
-            "weight": 1920.0
-          }
-        ],
-        "calories": 4278.876994575,
-        "totalWeight": 3318.6692775,
-        "totalTime": 10.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 4278.876994575,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 71.07698066225001,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 16.3080290662,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 0.12305087862500003,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 27.3695310345,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 17.908023754475003,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 667.4022327312499,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 19.634425000000004,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 31.98104,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 217.04189635250003,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 419.64746015000003,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 8873.130517375,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 599.935158675,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 367.36045290000004,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 3720.1606223500003,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 41.737490575500004,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 15.084024142250001,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 1942.1379052750003,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 122.99470087500002,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 12.528312255,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 6.260764822575,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 6.002902816824999,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 109.98667621027502,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 2.995234726475,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 1494.7109257250002,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 296.630925725,
-            "unit": "µg"
-          },
-          "FOLAC": {
-            "label": "Folic acid",
-            "quantity": 706.5600000000001,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 1.7470140580000002,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 14.741752025000002,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 2.4996979827500003,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 18.2022662725,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 213.94384972875,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 109.34920101884616,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 81.54014533099999,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 222.46741091041665,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 78.53770000000002,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 434.08379270500006,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 139.88248671666668,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 369.7137715572917,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 59.99351586750001,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 87.4667745,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 79.15235366702129,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 231.8749476416667,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 137.12749220227272,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 277.4482721821429,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 13.666077875000003,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 13.920346949999999,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 521.73040188125,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 461.7617551403845,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 687.4167263142189,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 230.40267126730768,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 373.6777314312501,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 72.79225241666668,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 98.27834683333336,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 16.664653218333335,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 15.168555227083335,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 71.07698066225001,
-            "hasRDI": true,
-            "daily": 109.34920101884616,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 16.3080290662,
-                "hasRDI": true,
-                "daily": 81.54014533099999,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 0.12305087862500003,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 27.3695310345,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 17.908023754475003,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 667.4022327312499,
-            "hasRDI": true,
-            "daily": 222.46741091041665,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 647.76780773125,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 19.634425000000004,
-                "hasRDI": true,
-                "daily": 78.53770000000002,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 31.98104,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 217.04189635250003,
-            "hasRDI": true,
-            "daily": 434.08379270500006,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 419.64746015000003,
-            "hasRDI": true,
-            "daily": 139.88248671666668,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 8873.130517375,
-            "hasRDI": true,
-            "daily": 369.7137715572917,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 599.935158675,
-            "hasRDI": true,
-            "daily": 59.99351586750001,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 367.36045290000004,
-            "hasRDI": true,
-            "daily": 87.4667745,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 3720.1606223500003,
-            "hasRDI": true,
-            "daily": 79.15235366702129,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 41.737490575500004,
-            "hasRDI": true,
-            "daily": 231.8749476416667,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 15.084024142250001,
-            "hasRDI": true,
-            "daily": 137.12749220227272,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 1942.1379052750003,
-            "hasRDI": true,
-            "daily": 277.4482721821429,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 122.99470087500002,
-            "hasRDI": true,
-            "daily": 13.666077875000003,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 12.528312255,
-            "hasRDI": true,
-            "daily": 13.920346949999999,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 6.260764822575,
-            "hasRDI": true,
-            "daily": 521.73040188125,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 6.002902816824999,
-            "hasRDI": true,
-            "daily": 461.7617551403845,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 109.98667621027502,
-            "hasRDI": true,
-            "daily": 687.4167263142189,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 2.995234726475,
-            "hasRDI": true,
-            "daily": 230.40267126730768,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 1494.7109257250002,
-            "hasRDI": true,
-            "daily": 373.6777314312501,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 296.630925725,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 706.5600000000001,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 1.7470140580000002,
-            "hasRDI": true,
-            "daily": 72.79225241666668,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 14.741752025000002,
-            "hasRDI": true,
-            "daily": 98.27834683333336,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 2.4996979827500003,
-            "hasRDI": true,
-            "daily": 16.664653218333335,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 18.2022662725,
-            "hasRDI": true,
-            "daily": 15.168555227083335,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_a798c432f454674f165d4a52e4fd83b4",
-        "label": "Chicken Marsala",
-        "image": "https://www.edamam.com/web-img/4de/4de0bd5b79b1d8f701bbf02d2afd0b80.jpg",
-        "source": "Saveur",
-        "url": "http://www.saveur.com/classic-chicken-marsala-recipe",
-        "shareAs": "http://www.edamam.com/recipe/chicken-marsala-a798c432f454674f165d4a52e4fd83b4/chicken",
-        "yield": 4.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free"
-        ],
-        "cautions": [
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "1¼ lb. chicken cutlets, pounded until ¼\" thick (about 8)",
-          "Kosher salt and freshly ground black pepper, to taste",
-          "⅓ cup flour",
-          "5 tbsp. olive oil",
-          "5 tbsp. unsalted butter",
-          "8 oz. white button mushrooms",
-          "2 tbsp. minced shallots",
-          "1 clove garlic, minced",
-          "⅓ cup dry marsala wine",
-          "⅓ cup chicken stock"
-        ],
-        "ingredients": [
-          {
-            "text": "1¼ lb. chicken cutlets, pounded until ¼\" thick (about 8)",
-            "weight": 566.9904625
-          },
-          {
-            "text": "Kosher salt and freshly ground black pepper, to taste",
-            "weight": 0.0
-          },
-          {
-            "text": "Kosher salt and freshly ground black pepper, to taste",
-            "weight": 3.4668599425
-          },
-          {
-            "text": "⅓ cup flour",
-            "weight": 41.666666666666664
-          },
-          {
-            "text": "5 tbsp. olive oil",
-            "weight": 67.5
-          },
-          {
-            "text": "5 tbsp. unsalted butter",
-            "weight": 71.0
-          },
-          {
-            "text": "8 oz. white button mushrooms",
-            "weight": 226.796185
-          },
-          {
-            "text": "2 tbsp. minced shallots",
-            "weight": 20.0
-          },
-          {
-            "text": "1 clove garlic, minced",
-            "weight": 3.0
-          },
-          {
-            "text": "⅓ cup dry marsala wine",
-            "weight": 78.66666666666666
-          },
-          {
-            "text": "⅓ cup chicken stock",
-            "weight": 80.0
-          }
-        ],
-        "calories": 2404.220574655675,
-        "totalWeight": 1159.0868407758335,
-        "totalTime": 121.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 2404.220574655675,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 179.82217777770884,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 61.362736418732936,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 2.9227199856249997,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 86.36322076247507,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 21.131794556559488,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 50.76457923089541,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 4.9730774154525,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 8.157319033298666,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 133.25525362910906,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 517.923896,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 500.47383928016666,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 130.01935930360833,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 195.47760277667496,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 2317.673787769159,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 7.296109114583418,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 6.441152828649084,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 1303.0490958924831,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 623.453763184475,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 7.458719885000001,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 0.6481364432962334,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 1.5341029047215005,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 66.4070196265928,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 3.4687993794160086,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 86.464336140225,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 86.464336140225,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 2.1391860465,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 149.19420695,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 12.982459210651998,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 51.776249725872496,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 120.21102873278376,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 276.64950427339824,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 306.8136820936647,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 16.92152641029847,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 19.89230966181,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 266.5105072582181,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 172.64129866666667,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 20.85307663667361,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 13.001935930360833,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 46.542286375398795,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 49.312208250407636,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 40.53393952546343,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 58.55593480590076,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 186.1498708417833,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 69.27264035383055,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 8.28746653888889,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 54.01137027468612,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 118.00791574780773,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 415.043872666205,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 266.8307214935391,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 21.61608403505625,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 89.1327519375,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 994.6280463333333,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 86.54972807101332,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 43.14687477156041,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 179.82217777770884,
-            "hasRDI": true,
-            "daily": 276.64950427339824,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 61.362736418732936,
-                "hasRDI": true,
-                "daily": 306.8136820936647,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 2.9227199856249997,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 86.36322076247507,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 21.131794556559488,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 50.76457923089541,
-            "hasRDI": true,
-            "daily": 16.92152641029847,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 45.791501815442906,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 4.9730774154525,
-                "hasRDI": true,
-                "daily": 19.89230966181,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 8.157319033298666,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 133.25525362910906,
-            "hasRDI": true,
-            "daily": 266.5105072582181,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 517.923896,
-            "hasRDI": true,
-            "daily": 172.64129866666667,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 500.47383928016666,
-            "hasRDI": true,
-            "daily": 20.85307663667361,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 130.01935930360833,
-            "hasRDI": true,
-            "daily": 13.001935930360833,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 195.47760277667496,
-            "hasRDI": true,
-            "daily": 46.542286375398795,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 2317.673787769159,
-            "hasRDI": true,
-            "daily": 49.312208250407636,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 7.296109114583418,
-            "hasRDI": true,
-            "daily": 40.53393952546343,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 6.441152828649084,
-            "hasRDI": true,
-            "daily": 58.55593480590076,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 1303.0490958924831,
-            "hasRDI": true,
-            "daily": 186.1498708417833,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 623.453763184475,
-            "hasRDI": true,
-            "daily": 69.27264035383055,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 7.458719885000001,
-            "hasRDI": true,
-            "daily": 8.28746653888889,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 0.6481364432962334,
-            "hasRDI": true,
-            "daily": 54.01137027468612,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 1.5341029047215005,
-            "hasRDI": true,
-            "daily": 118.00791574780773,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 66.4070196265928,
-            "hasRDI": true,
-            "daily": 415.043872666205,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 3.4687993794160086,
-            "hasRDI": true,
-            "daily": 266.8307214935391,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 86.464336140225,
-            "hasRDI": true,
-            "daily": 21.61608403505625,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 86.464336140225,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 2.1391860465,
-            "hasRDI": true,
-            "daily": 89.1327519375,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 149.19420695,
-            "hasRDI": true,
-            "daily": 994.6280463333333,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 12.982459210651998,
-            "hasRDI": true,
-            "daily": 86.54972807101332,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 51.776249725872496,
-            "hasRDI": true,
-            "daily": 43.14687477156041,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_3b7cb2359876b5b27920156479e3286f",
-        "label": "Roasted Chicken",
-        "image": "https://www.edamam.com/web-img/530/53086a28442e65f61bd8e68abd7f58f7.jpg",
-        "source": "Food52",
-        "url": "https://food52.com/recipes/4527-roasted-chicken",
-        "shareAs": "http://www.edamam.com/recipe/roasted-chicken-3b7cb2359876b5b27920156479e3286f/chicken",
-        "yield": 2.0,
-        "dietLabels": [],
-        "healthLabels": [
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "Sulfites",
-          "FODMAP"
-        ],
-        "ingredientLines": [
-          "1 whole chicken (3-4 lbs.)",
-          "3-4 carrots, peeled and sliced",
-          "3 celery ribs, sliced",
-          "1 onion, roughly chopped",
-          "3 tablespoons olive oil",
-          "2 teaspoons dried thyme",
-          "2 teaspoons herbs de provence",
-          "1 teaspoon dried sage",
-          "Salt and pepper",
-          "2 cups chicken stock",
-          "5 sliced wheat bread, cubed"
-        ],
-        "ingredients": [
-          {
-            "text": "1 whole chicken (3-4 lbs.)",
-            "weight": 1587.5732950000001
-          },
-          {
-            "text": "3-4 carrots, peeled and sliced",
-            "weight": 213.5
-          },
-          {
-            "text": "3 celery ribs, sliced",
-            "weight": 120.0
-          },
-          {
-            "text": "1 onion, roughly chopped",
-            "weight": 125.0
-          },
-          {
-            "text": "3 tablespoons olive oil",
-            "weight": 40.5
-          },
-          {
-            "text": "2 teaspoons dried thyme",
-            "weight": 2.0
-          },
-          {
-            "text": "2 teaspoons herbs de provence",
-            "weight": 2.0
-          },
-          {
-            "text": "1 teaspoon dried sage",
-            "weight": 0.7
-          },
-          {
-            "text": "Salt and pepper",
-            "weight": 26.947639770000002
-          },
-          {
-            "text": "Salt and pepper",
-            "weight": 13.473819885000001
-          },
-          {
-            "text": "2 cups chicken stock",
-            "weight": 480.0
-          },
-          {
-            "text": "5 sliced wheat bread, cubed",
-            "weight": 1920.0
-          }
-        ],
-        "calories": 8182.051445201349,
-        "totalWeight": 4504.747114885,
-        "totalTime": 176.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 8182.051445201349,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 272.71530252261095,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 69.1078987026592,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 1.5463633453819998,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 111.57711658239015,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 69.4947085738323,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 998.8915178164574,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 91.993976430905,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 138.25050244726398,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 424.74356023765154,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 824.06238045,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 11449.781652397,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 2981.21350455655,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 1185.2662001233498,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 7339.971265005651,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 85.55089647623349,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 38.9834413684915,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 4747.0789011003,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 2269.843366014951,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 49.866097449600005,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 9.0476896298358,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 6.829604684513,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 191.94673542049154,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 6.81589325796535,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 2112.2565398164497,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 1459.45653981645,
-            "unit": "µg"
-          },
-          "FOLAC": {
-            "label": "Folic acid",
-            "quantity": 384.0,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 3.34660450586,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 107.95498406,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 15.092187248603999,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 302.094390760745,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 409.10257226006746,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 419.5620038809399,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 345.53949351329595,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 332.9638392721524,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 367.9759057236199,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 849.4871204753031,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 274.68746015,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 477.0742355165416,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 298.12135045565503,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 282.2062381246071,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 156.16960138309895,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 475.28275820129716,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 354.3949215317409,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 678.1541287286142,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 252.20481844610563,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 55.406774944,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 753.97413581965,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 525.354206501,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 1199.667096378072,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 524.29948138195,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 528.0641349541124,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 139.44185441083332,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 719.6998937333334,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 100.61458165735999,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 251.74532563395417,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 272.71530252261095,
-            "hasRDI": true,
-            "daily": 419.5620038809399,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 69.1078987026592,
-                "hasRDI": true,
-                "daily": 345.53949351329595,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 1.5463633453819998,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 111.57711658239015,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 69.4947085738323,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 998.8915178164574,
-            "hasRDI": true,
-            "daily": 332.9638392721524,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 906.8975413855524,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 91.993976430905,
-                "hasRDI": true,
-                "daily": 367.9759057236199,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 138.25050244726398,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 424.74356023765154,
-            "hasRDI": true,
-            "daily": 849.4871204753031,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 824.06238045,
-            "hasRDI": true,
-            "daily": 274.68746015,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 11449.781652397,
-            "hasRDI": true,
-            "daily": 477.0742355165416,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 2981.21350455655,
-            "hasRDI": true,
-            "daily": 298.12135045565503,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 1185.2662001233498,
-            "hasRDI": true,
-            "daily": 282.2062381246071,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 7339.971265005651,
-            "hasRDI": true,
-            "daily": 156.16960138309895,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 85.55089647623349,
-            "hasRDI": true,
-            "daily": 475.28275820129716,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 38.9834413684915,
-            "hasRDI": true,
-            "daily": 354.3949215317409,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 4747.0789011003,
-            "hasRDI": true,
-            "daily": 678.1541287286142,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 2269.843366014951,
-            "hasRDI": true,
-            "daily": 252.20481844610563,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 49.866097449600005,
-            "hasRDI": true,
-            "daily": 55.406774944,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 9.0476896298358,
-            "hasRDI": true,
-            "daily": 753.97413581965,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 6.829604684513,
-            "hasRDI": true,
-            "daily": 525.354206501,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 191.94673542049154,
-            "hasRDI": true,
-            "daily": 1199.667096378072,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 6.81589325796535,
-            "hasRDI": true,
-            "daily": 524.29948138195,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 2112.2565398164497,
-            "hasRDI": true,
-            "daily": 528.0641349541124,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 1459.45653981645,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 384.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 3.34660450586,
-            "hasRDI": true,
-            "daily": 139.44185441083332,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 107.95498406,
-            "hasRDI": true,
-            "daily": 719.6998937333334,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 15.092187248603999,
-            "hasRDI": true,
-            "daily": 100.61458165735999,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 302.094390760745,
-            "hasRDI": true,
-            "daily": 251.74532563395417,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_b550f7f1182bc4d97f5473bcf15cf006",
-        "label": "Chicken cacciatore",
-        "image": "https://www.edamam.com/web-img/2ca/2ca946a40338e9b93c1d14dec518e1b8.jpg",
-        "source": "BBC",
-        "url": "http://www.bbc.co.uk/food/recipes/chickenalocacciatore_70349",
-        "shareAs": "http://www.edamam.com/recipe/chicken-cacciatore-b550f7f1182bc4d97f5473bcf15cf006/chicken",
-        "yield": 6.0,
-        "dietLabels": [],
-        "healthLabels": [
-          "Peanut-Free",
-          "Tree-Nut-Free"
-        ],
-        "cautions": [
-          "Sulfites",
-          "FODMAP"
-        ],
-        "ingredientLines": [
-          "8 tbsp olive oil",
-          "1 onion, sliced",
-          "2 celery stalks, roughly chopped",
-          "2 medium carrots, roughly chopped",
-          "6 chicken breasts, or chicken thighs, bones removed",
-          "175ml/6fl oz white wine",
-          "3 tbsp tomato purée",
-          "500ml/17 fl oz chicken stock",
-          "2 bay leaves",
-          "2-3 sage leaves",
-          "1 rosemary sprig",
-          "250g/9oz easy-cook polenta",
-          "Knob of butter",
-          "25g/1oz parmesan"
-        ],
-        "ingredients": [
-          {
-            "text": "8 tbsp olive oil",
-            "weight": 108.0
-          },
-          {
-            "text": "1 onion, sliced",
-            "weight": 125.0
-          },
-          {
-            "text": "2 celery stalks, roughly chopped",
-            "weight": 80.0
-          },
-          {
-            "text": "2 medium carrots, roughly chopped",
-            "weight": 122.0
-          },
-          {
-            "text": "6 chicken breasts, or chicken thighs, bones removed",
-            "weight": 1044.0
-          },
-          {
-            "text": "175ml/6fl oz white wine",
-            "weight": 173.97314680098222
-          },
-          {
-            "text": "3 tbsp tomato purée",
-            "weight": 42.599999999999994
-          },
-          {
-            "text": "500ml/17 fl oz chicken stock",
-            "weight": 507.21034052764503
-          },
-          {
-            "text": "2 bay leaves",
-            "weight": 1.2
-          },
-          {
-            "text": "2-3 sage leaves",
-            "weight": 2.5
-          },
-          {
-            "text": "1 rosemary sprig",
-            "weight": 5.0
-          },
-          {
-            "text": "250g/9oz easy-cook polenta",
-            "weight": 250.0
-          },
-          {
-            "text": "Knob of butter",
-            "weight": 28.4
-          },
-          {
-            "text": "25g/1oz parmesan",
-            "weight": 25.0
-          }
-        ],
-        "calories": 4446.914702966757,
-        "totalWeight": 2514.8834873286273,
-        "totalTime": 60.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 4446.914702966757,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 245.90941408633174,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 64.04548719309375,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 2.0271519999999996,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 130.6560361818709,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 36.37591802532388,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 254.1718968374514,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 19.4085,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 27.998055589626222,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 261.81419178405736,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 761.4363102158293,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 1992.7804442945815,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 639.7618934279178,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 451.403728301204,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 4311.003791782724,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 15.719749211470706,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 12.56664225289988,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 2531.3509583666414,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 1588.5071034052762,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 26.31962068105529,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 1.412640276524725,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 1.7555947614686456,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 116.57479279250295,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 6.954576881122355,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 242.19024849439202,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 242.19024849439202,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 3.89788,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 188.82999999999998,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 21.248543102158294,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 154.30361326825923,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 222.34573514833787,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 378.32217551743344,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 320.22743596546877,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 84.72396561248381,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 77.634,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 523.6283835681147,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 253.81210340527642,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 83.03251851227424,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 63.976189342791784,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 107.47707816695333,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 91.72348493154732,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 87.33194006372614,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 114.24220229908983,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 361.6215654809488,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 176.5007892672529,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 29.244022978950323,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 117.72002304372708,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 135.04575088220352,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 728.5924549531434,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 534.9674523940273,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 60.547562123598006,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 162.41166666666666,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 1258.8666666666666,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 141.65695401438862,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 128.58634439021603,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 245.90941408633174,
-            "hasRDI": true,
-            "daily": 378.32217551743344,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 64.04548719309375,
-                "hasRDI": true,
-                "daily": 320.22743596546877,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 2.0271519999999996,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 130.6560361818709,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 36.37591802532388,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 254.1718968374514,
-            "hasRDI": true,
-            "daily": 84.72396561248381,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 234.7633968374514,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 19.4085,
-                "hasRDI": true,
-                "daily": 77.634,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 27.998055589626222,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 261.81419178405736,
-            "hasRDI": true,
-            "daily": 523.6283835681147,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 761.4363102158293,
-            "hasRDI": true,
-            "daily": 253.81210340527642,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 1992.7804442945815,
-            "hasRDI": true,
-            "daily": 83.03251851227424,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 639.7618934279178,
-            "hasRDI": true,
-            "daily": 63.976189342791784,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 451.403728301204,
-            "hasRDI": true,
-            "daily": 107.47707816695333,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 4311.003791782724,
-            "hasRDI": true,
-            "daily": 91.72348493154732,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 15.719749211470706,
-            "hasRDI": true,
-            "daily": 87.33194006372614,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 12.56664225289988,
-            "hasRDI": true,
-            "daily": 114.24220229908983,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 2531.3509583666414,
-            "hasRDI": true,
-            "daily": 361.6215654809488,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 1588.5071034052762,
-            "hasRDI": true,
-            "daily": 176.5007892672529,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 26.31962068105529,
-            "hasRDI": true,
-            "daily": 29.244022978950323,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 1.412640276524725,
-            "hasRDI": true,
-            "daily": 117.72002304372708,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 1.7555947614686456,
-            "hasRDI": true,
-            "daily": 135.04575088220352,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 116.57479279250295,
-            "hasRDI": true,
-            "daily": 728.5924549531434,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 6.954576881122355,
-            "hasRDI": true,
-            "daily": 534.9674523940273,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 242.19024849439202,
-            "hasRDI": true,
-            "daily": 60.547562123598006,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 242.19024849439202,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 3.89788,
-            "hasRDI": true,
-            "daily": 162.41166666666666,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 188.82999999999998,
-            "hasRDI": true,
-            "daily": 1258.8666666666666,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 21.248543102158294,
-            "hasRDI": true,
-            "daily": 141.65695401438862,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 154.30361326825923,
-            "hasRDI": true,
-            "daily": 128.58634439021603,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_71ab1bfee5b89e904185ef03c337d52b",
-        "label": "Tarragon Chicken",
-        "image": "https://www.edamam.com/web-img/b28/b28acc0eed7e65de535d36954006f358.jpg",
-        "source": "French Revolution Food",
-        "url": "http://www.frenchrevolutionfood.com/2009/09/french-in-a-flash-tarragon-chicken-and-carrot-muffins-with-sweet-chevre-icing/",
-        "shareAs": "http://www.edamam.com/recipe/tarragon-chicken-71ab1bfee5b89e904185ef03c337d52b/chicken",
-        "yield": 4.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Peanut-Free",
-          "Tree-Nut-Free"
-        ],
-        "cautions": [
-          "Gluten",
-          "Wheat",
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "8 vine ripened tomatoes, peeled, seeded, and finely diced",
-          "8 chicken legs",
-          "8 chicken thighs",
-          "2 tablespoons olive oil, plus 1 tablespoon",
-          "4 shallots, roughly chopped",
-          "2 cloves garlic, smashed",
-          "1/3 cup dry vermouth",
-          "1/3 cup dry white wine",
-          "1 cup low-sodium chicken stock",
-          "6 stems tarragon"
-        ],
-        "ingredients": [
-          {
-            "text": "8 vine ripened tomatoes, peeled, seeded, and finely diced",
-            "weight": 984.0
-          },
-          {
-            "text": "8 chicken legs",
-            "weight": 2752.0
-          },
-          {
-            "text": "8 chicken thighs",
-            "weight": 1192.0
-          },
-          {
-            "text": "2 tablespoons olive oil, plus 1 tablespoon",
-            "weight": 27.0
-          },
-          {
-            "text": "2 tablespoons olive oil, plus 1 tablespoon",
-            "weight": 13.5
-          },
-          {
-            "text": "4 shallots, roughly chopped",
-            "weight": 236.44444444444446
-          },
-          {
-            "text": "2 cloves garlic, smashed",
-            "weight": 6.0
-          },
-          {
-            "text": "1/3 cup dry vermouth",
-            "weight": 78.66666666666666
-          },
-          {
-            "text": "1/3 cup dry white wine",
-            "weight": 75.33333333333333
-          },
-          {
-            "text": "1 cup low-sodium chicken stock",
-            "weight": 240.0
-          },
-          {
-            "text": "6 stems tarragon",
-            "weight": 10.8
-          }
-        ],
-        "calories": 9435.246666666666,
-        "totalWeight": 5615.7444444444445,
-        "totalTime": 211.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 9435.246666666666,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 681.8915644444445,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 180.62444355555553,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 2.6644,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 295.4764792222222,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 139.4611523333333,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 100.04442666666668,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 20.299422222222223,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 46.20404444444444,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 669.7396711111112,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 3727.5200000000004,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 3442.999333333333,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 673.9547777777778,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 952.896,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 11828.436111111108,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 37.40419999999999,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 59.37324444444445,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 6659.344000000002,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 1480.68,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 166.49955555555553,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 3.431874666666666,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 6.095574222222222,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 196.2085555555555,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 14.92906,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 405.1431111111111,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 405.1431111111111,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 23.0416,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 90.8,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 19.782327777777777,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 192.73988888888888,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 471.7623333333333,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 1049.0639452991454,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 903.1222177777776,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 33.34814222222223,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 81.19768888888889,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 1339.4793422222224,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 1242.506666666667,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 143.45830555555557,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 67.39547777777778,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 226.87999999999997,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 251.6688534278959,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 207.80111111111103,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 539.7567676767677,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 951.3348571428573,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 164.52,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 184.99950617283946,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 285.9895555555555,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 468.8903247863247,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 1226.303472222222,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 1148.3892307692306,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 101.28577777777778,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 960.0666666666666,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 605.3333333333334,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 131.8821851851852,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 160.61657407407407,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 681.8915644444445,
-            "hasRDI": true,
-            "daily": 1049.0639452991454,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 180.62444355555553,
-                "hasRDI": true,
-                "daily": 903.1222177777776,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 2.6644,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 295.4764792222222,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 139.4611523333333,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 100.04442666666668,
-            "hasRDI": true,
-            "daily": 33.34814222222223,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 79.74500444444446,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 20.299422222222223,
-                "hasRDI": true,
-                "daily": 81.19768888888889,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 46.20404444444444,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 669.7396711111112,
-            "hasRDI": true,
-            "daily": 1339.4793422222224,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 3727.5200000000004,
-            "hasRDI": true,
-            "daily": 1242.506666666667,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 3442.999333333333,
-            "hasRDI": true,
-            "daily": 143.45830555555557,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 673.9547777777778,
-            "hasRDI": true,
-            "daily": 67.39547777777778,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 952.896,
-            "hasRDI": true,
-            "daily": 226.87999999999997,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 11828.436111111108,
-            "hasRDI": true,
-            "daily": 251.6688534278959,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 37.40419999999999,
-            "hasRDI": true,
-            "daily": 207.80111111111103,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 59.37324444444445,
-            "hasRDI": true,
-            "daily": 539.7567676767677,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 6659.344000000002,
-            "hasRDI": true,
-            "daily": 951.3348571428573,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 1480.68,
-            "hasRDI": true,
-            "daily": 164.52,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 166.49955555555553,
-            "hasRDI": true,
-            "daily": 184.99950617283946,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 3.431874666666666,
-            "hasRDI": true,
-            "daily": 285.9895555555555,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 6.095574222222222,
-            "hasRDI": true,
-            "daily": 468.8903247863247,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 196.2085555555555,
-            "hasRDI": true,
-            "daily": 1226.303472222222,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 14.92906,
-            "hasRDI": true,
-            "daily": 1148.3892307692306,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 405.1431111111111,
-            "hasRDI": true,
-            "daily": 101.28577777777778,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 405.1431111111111,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 23.0416,
-            "hasRDI": true,
-            "daily": 960.0666666666666,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 90.8,
-            "hasRDI": true,
-            "daily": 605.3333333333334,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 19.782327777777777,
-            "hasRDI": true,
-            "daily": 131.8821851851852,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 192.73988888888888,
-            "hasRDI": true,
-            "daily": 160.61657407407407,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_63f409a7fbec68dbd88e6240c85d81b4",
-        "label": "Chicken Soup",
-        "image": "https://www.edamam.com/web-img/e20/e20d522d53088284fc5a31f365cbdebd.jpg",
-        "source": "Cookstr",
-        "url": "http://www.cookstr.com/recipes/chicken-soup-3-sharon-lebewohl",
-        "shareAs": "http://www.edamam.com/recipe/chicken-soup-63f409a7fbec68dbd88e6240c85d81b4/chicken",
-        "yield": 8.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "FODMAP"
-        ],
-        "ingredientLines": [
-          "1 pound chicken parts",
-          "2 stalks celery, including leafy tops, cut into 3-inch pieces",
-          "1 whole chicken, thoroughly rinsed",
-          "Salt to rub inside the chicken",
-          "1 large whole onion, unpeeled (find one with a firm, golden-brown peel)",
-          "1 large whole carrot, peeled",
-          "1 medium parsnip, peeled",
-          "2 teaspoons salt",
-          "¼ teaspoon pepper",
-          "1 bunch dill, cleaned and tied with a string"
-        ],
-        "ingredients": [
-          {
-            "text": "1 pound chicken parts",
-            "weight": 453.59237
-          },
-          {
-            "text": "2 stalks celery, including leafy tops, cut into 3-inch pieces",
-            "weight": 80.0
-          },
-          {
-            "text": "1 whole chicken, thoroughly rinsed",
-            "weight": 920.0
-          },
-          {
-            "text": "Salt to rub inside the chicken",
-            "weight": 10.94230422
-          },
-          {
-            "text": "1 large whole onion, unpeeled (find one with a firm, golden-brown peel)",
-            "weight": 150.0
-          },
-          {
-            "text": "1 large whole carrot, peeled",
-            "weight": 72.0
-          },
-          {
-            "text": "1 medium parsnip, peeled",
-            "weight": 133.0
-          },
-          {
-            "text": "2 teaspoons salt",
-            "weight": 12.0
-          },
-          {
-            "text": "¼ teaspoon pepper",
-            "weight": 0.725
-          },
-          {
-            "text": "1 bunch dill, cleaned and tied with a string",
-            "weight": 2.4
-          }
-        ],
-        "calories": 3185.3608877000006,
-        "totalWeight": 1819.630868348438,
-        "totalTime": 120.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 3185.3608877000006,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 214.80200765700005,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 60.37379081880001,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 1.2779535145,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 89.11605622800002,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 45.68701296790001,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 48.976398425,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 12.596825,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 17.233439999999998,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 250.67942702400006,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 1134.5205226000003,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 4213.112509587602,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 281.19445550362514,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 339.2955115834844,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 3848.2587646678753,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 13.094800160549848,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 19.258222571348437,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 2249.5995209,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 1109.7859951,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 57.198,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 1.1383174301,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 1.9644779365,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 85.6625738625,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 5.2587752738999995,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 232.6210211,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 232.6210211,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 5.664272694000001,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 105.60777110000001,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 6.4229839769999995,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 87.98126477,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 159.26804438500002,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 330.4646271646154,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 301.86895409400006,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 16.325466141666666,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 50.3873,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 501.3588540480001,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 378.1735075333334,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 175.5463545661501,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 28.119445550362514,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 80.78464561511534,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 81.8778460567633,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 72.74888978083249,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 175.07475064862217,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 321.3713601285714,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 123.30955501111112,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 63.553333333333335,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 94.85978584166668,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 151.11368742307693,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 535.391086640625,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 404.52117491538456,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 58.155255275,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 236.01136225000005,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 704.0518073333334,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 42.819893179999994,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 73.31772064166667,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 214.80200765700005,
-            "hasRDI": true,
-            "daily": 330.4646271646154,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 60.37379081880001,
-                "hasRDI": true,
-                "daily": 301.86895409400006,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 1.2779535145,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 89.11605622800002,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 45.68701296790001,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 48.976398425,
-            "hasRDI": true,
-            "daily": 16.325466141666666,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 36.379573425,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 12.596825,
-                "hasRDI": true,
-                "daily": 50.3873,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 17.233439999999998,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 250.67942702400006,
-            "hasRDI": true,
-            "daily": 501.3588540480001,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 1134.5205226000003,
-            "hasRDI": true,
-            "daily": 378.1735075333334,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 4213.112509587602,
-            "hasRDI": true,
-            "daily": 175.5463545661501,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 281.19445550362514,
-            "hasRDI": true,
-            "daily": 28.119445550362514,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 339.2955115834844,
-            "hasRDI": true,
-            "daily": 80.78464561511534,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 3848.2587646678753,
-            "hasRDI": true,
-            "daily": 81.8778460567633,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 13.094800160549848,
-            "hasRDI": true,
-            "daily": 72.74888978083249,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 19.258222571348437,
-            "hasRDI": true,
-            "daily": 175.07475064862217,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 2249.5995209,
-            "hasRDI": true,
-            "daily": 321.3713601285714,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 1109.7859951,
-            "hasRDI": true,
-            "daily": 123.30955501111112,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 57.198,
-            "hasRDI": true,
-            "daily": 63.553333333333335,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 1.1383174301,
-            "hasRDI": true,
-            "daily": 94.85978584166668,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 1.9644779365,
-            "hasRDI": true,
-            "daily": 151.11368742307693,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 85.6625738625,
-            "hasRDI": true,
-            "daily": 535.391086640625,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 5.2587752738999995,
-            "hasRDI": true,
-            "daily": 404.52117491538456,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 232.6210211,
-            "hasRDI": true,
-            "daily": 58.155255275,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 232.6210211,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 5.664272694000001,
-            "hasRDI": true,
-            "daily": 236.01136225000005,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 105.60777110000001,
-            "hasRDI": true,
-            "daily": 704.0518073333334,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 6.4229839769999995,
-            "hasRDI": true,
-            "daily": 42.819893179999994,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 87.98126477,
-            "hasRDI": true,
-            "daily": 73.31772064166667,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_2f0f56abdb4b8ee95fc08f6e4adb443c",
-        "label": "Chicken Saltimbocca",
-        "image": "https://www.edamam.com/web-img/36f/36f50faee795ad7c689c16afb606465d.jpg",
-        "source": "Cooking Channel",
-        "url": "http://www.cookingchanneltv.com/recipes/chicken-saltimbocca.html",
-        "shareAs": "http://www.edamam.com/recipe/chicken-saltimbocca-2f0f56abdb4b8ee95fc08f6e4adb443c/chicken",
-        "yield": 6.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "Gluten",
-          "Wheat",
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "6 (3-ounce) chicken cutlets, pounded to evenly flatten",
-          "Salt and freshly ground black pepper",
-          "6 paper-thin slices prosciutto",
-          "1 (10-ounce) box frozen chopped spinach, thawed",
-          "3 tablespoons olive oil",
-          "1/4 cup grated parmesan",
-          "1 (14-ounce) can low-salt chicken broth",
-          "2 tablespoons fresh lemon juice"
-        ],
-        "ingredients": [
-          {
-            "text": "6 (3-ounce) chicken cutlets, pounded to evenly flatten",
-            "weight": 510.29141625
-          },
-          {
-            "text": "Salt and freshly ground black pepper",
-            "weight": 8.2645798275
-          },
-          {
-            "text": "Salt and freshly ground black pepper",
-            "weight": 4.13228991375
-          },
-          {
-            "text": "6 paper-thin slices prosciutto",
-            "weight": 90.0
-          },
-          {
-            "text": "1 (10-ounce) box frozen chopped spinach, thawed",
-            "weight": 283.49523125
-          },
-          {
-            "text": "3 tablespoons olive oil",
-            "weight": 40.5
-          },
-          {
-            "text": "1/4 cup grated parmesan",
-            "weight": 28.25
-          },
-          {
-            "text": "1 (14-ounce) can low-salt chicken broth",
-            "weight": 396.89332375000004
-          },
-          {
-            "text": "2 tablespoons fresh lemon juice",
-            "weight": 28.0
-          }
-        ],
-        "calories": 1491.6598714310128,
-        "totalWeight": 1381.56226116375,
-        "totalTime": 35.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 1491.6598714310128,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 96.73544379806326,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 24.546828858599405,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 0.42864478965,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 51.85365303326262,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 14.311899879626724,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 20.807846179218124,
-            "unit": "g"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 7.366364435678751,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 2.6646879475730003,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 136.80915824128866,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 343.47920512,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 3416.35256158525,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 705.3127008354124,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 373.6646649275125,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 3390.4976743537377,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 13.418217281575126,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 8.534332363348625,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 1459.330329921225,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 1487.1618047592126,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 90.49815998125,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 1.0108135272718501,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 1.3251002690822502,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 51.57985240097916,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 3.184753101861513,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 579.0900632303375,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 579.0900632303375,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 2.91588597595,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 103.98480128000003,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 13.068058468578,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 1400.624280295059,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 74.58299357155065,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 148.82375968932809,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 122.73414429299703,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 6.935948726406041,
-            "unit": "%"
-          },
-          "FIBTG": {
-            "label": "Fiber",
-            "quantity": 29.465457742715003,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 273.6183164825773,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 114.49306837333334,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 142.34802339938543,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 70.53127008354124,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 88.96777736369346,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 72.13824839050507,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 74.54565156430625,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 77.58483966680568,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 208.47576141731784,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 165.24020052880138,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 100.55351109027777,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 84.23446060598752,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 101.93078992940387,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 322.37407750611976,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 244.981007835501,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 144.77251580758437,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 121.49524899791668,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 693.2320085333336,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 87.12038979052,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 1167.1869002458823,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 96.73544379806326,
-            "hasRDI": true,
-            "daily": 148.82375968932809,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 24.546828858599405,
-                "hasRDI": true,
-                "daily": 122.73414429299703,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 0.42864478965,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 51.85365303326262,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 14.311899879626724,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 20.807846179218124,
-            "hasRDI": true,
-            "daily": 6.935948726406041,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 13.441481743539374,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 7.366364435678751,
-                "hasRDI": true,
-                "daily": 29.465457742715003,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 2.6646879475730003,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 136.80915824128866,
-            "hasRDI": true,
-            "daily": 273.6183164825773,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 343.47920512,
-            "hasRDI": true,
-            "daily": 114.49306837333334,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 3416.35256158525,
-            "hasRDI": true,
-            "daily": 142.34802339938543,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 705.3127008354124,
-            "hasRDI": true,
-            "daily": 70.53127008354124,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 373.6646649275125,
-            "hasRDI": true,
-            "daily": 88.96777736369346,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 3390.4976743537377,
-            "hasRDI": true,
-            "daily": 72.13824839050507,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 13.418217281575126,
-            "hasRDI": true,
-            "daily": 74.54565156430625,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 8.534332363348625,
-            "hasRDI": true,
-            "daily": 77.58483966680568,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 1459.330329921225,
-            "hasRDI": true,
-            "daily": 208.47576141731784,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 1487.1618047592126,
-            "hasRDI": true,
-            "daily": 165.24020052880138,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 90.49815998125,
-            "hasRDI": true,
-            "daily": 100.55351109027777,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 1.0108135272718501,
-            "hasRDI": true,
-            "daily": 84.23446060598752,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 1.3251002690822502,
-            "hasRDI": true,
-            "daily": 101.93078992940387,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 51.57985240097916,
-            "hasRDI": true,
-            "daily": 322.37407750611976,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 3.184753101861513,
-            "hasRDI": true,
-            "daily": 244.981007835501,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 579.0900632303375,
-            "hasRDI": true,
-            "daily": 144.77251580758437,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 579.0900632303375,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 2.91588597595,
-            "hasRDI": true,
-            "daily": 121.49524899791668,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 103.98480128000003,
-            "hasRDI": true,
-            "daily": 693.2320085333336,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 13.068058468578,
-            "hasRDI": true,
-            "daily": 87.12038979052,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 1400.624280295059,
-            "hasRDI": true,
-            "daily": 1167.1869002458823,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    },
-    {
-      "recipe": {
-        "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_12fafbb01eadad8203145452e7ddc885",
-        "label": "Easy Chicken Stock",
-        "image": "https://www.edamam.com/web-img/2fe/2fe1ba60ec3448742e895cd495c3d843.jpg",
-        "source": "My Recipes",
-        "url": "http://www.myrecipes.com/recipe/easy-chicken-stock",
-        "shareAs": "http://www.edamam.com/recipe/easy-chicken-stock-12fafbb01eadad8203145452e7ddc885/chicken",
-        "yield": 10.0,
-        "dietLabels": [
-          "Low-Carb"
-        ],
-        "healthLabels": [
-          "Sugar-Conscious",
-          "Peanut-Free",
-          "Tree-Nut-Free",
-          "Alcohol-Free"
-        ],
-        "cautions": [
-          "Sulfites"
-        ],
-        "ingredientLines": [
-          "2 pounds  chicken wings",
-          "2   (32-oz.) containers chicken broth"
-        ],
-        "ingredients": [
-          {
-            "text": "2 pounds  chicken wings",
-            "weight": 907.18474
-          },
-          {
-            "text": "2   (32-oz.) containers chicken broth",
-            "weight": 1814.36948
-          }
-        ],
-        "calories": 2385.8958662000005,
-        "totalWeight": 2721.55422,
-        "totalTime": 90.0,
-        "totalNutrients": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 2385.8958662000005,
-            "unit": "kcal"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 141.15794554400003,
-            "unit": "g"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 42.66489832220001,
-            "unit": "g"
-          },
-          "FATRN": {
-            "label": "Trans",
-            "quantity": 0.6350293180000002,
-            "unit": "g"
-          },
-          "FAMS": {
-            "label": "Monounsaturated",
-            "quantity": 67.05909598080001,
-            "unit": "g"
-          },
-          "FAPU": {
-            "label": "Polyunsaturated",
-            "quantity": 29.882665335600002,
-            "unit": "g"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 64.04724264400001,
-            "unit": "g"
-          },
-          "SUGAR": {
-            "label": "Sugars",
-            "quantity": 28.667037784000005,
-            "unit": "g"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 204.66087734400003,
-            "unit": "g"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 1061.4061458,
-            "unit": "mg"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 3356.5835380000003,
-            "unit": "mg"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 154.2214058,
-            "unit": "mg"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 217.7243376,
-            "unit": "mg"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 3601.5234178000005,
-            "unit": "mg"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 7.983225712000001,
-            "unit": "mg"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 13.517052626000002,
-            "unit": "mg"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 1605.7169898000002,
-            "unit": "mg"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 99.79032140000001,
-            "unit": "µg"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 3.6287389600000006,
-            "unit": "mg"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 1.1249090776000004,
-            "unit": "mg"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 2.4766143402000003,
-            "unit": "mg"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 80.42192720100002,
-            "unit": "mg"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 5.8967008100000005,
-            "unit": "mg"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 154.2214058,
-            "unit": "µg"
-          },
-          "FOLFD": {
-            "label": "Folate (food)",
-            "quantity": 154.2214058,
-            "unit": "µg"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 2.2679618500000003,
-            "unit": "µg"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 45.35923700000001,
-            "unit": "IU"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 6.35029318,
-            "unit": "mg"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 38.10175908,
-            "unit": "µg"
-          }
-        },
-        "totalDaily": {
-          "ENERC_KCAL": {
-            "label": "Energy",
-            "quantity": 119.29479331000002,
-            "unit": "%"
-          },
-          "FAT": {
-            "label": "Fat",
-            "quantity": 217.16607006769235,
-            "unit": "%"
-          },
-          "FASAT": {
-            "label": "Saturated",
-            "quantity": 213.32449161100004,
-            "unit": "%"
-          },
-          "CHOCDF": {
-            "label": "Carbs",
-            "quantity": 21.349080881333336,
-            "unit": "%"
-          },
-          "PROCNT": {
-            "label": "Protein",
-            "quantity": 409.32175468800006,
-            "unit": "%"
-          },
-          "CHOLE": {
-            "label": "Cholesterol",
-            "quantity": 353.80204860000003,
-            "unit": "%"
-          },
-          "NA": {
-            "label": "Sodium",
-            "quantity": 139.85764741666668,
-            "unit": "%"
-          },
-          "CA": {
-            "label": "Calcium",
-            "quantity": 15.42214058,
-            "unit": "%"
-          },
-          "MG": {
-            "label": "Magnesium",
-            "quantity": 51.839128,
-            "unit": "%"
-          },
-          "K": {
-            "label": "Potassium",
-            "quantity": 76.62815782553193,
-            "unit": "%"
-          },
-          "FE": {
-            "label": "Iron",
-            "quantity": 44.35125395555556,
-            "unit": "%"
-          },
-          "ZN": {
-            "label": "Zinc",
-            "quantity": 122.88229660000002,
-            "unit": "%"
-          },
-          "P": {
-            "label": "Phosphorus",
-            "quantity": 229.38814140000002,
-            "unit": "%"
-          },
-          "VITA_RAE": {
-            "label": "Vitamin A",
-            "quantity": 11.08781348888889,
-            "unit": "%"
-          },
-          "VITC": {
-            "label": "Vitamin C",
-            "quantity": 4.031932177777779,
-            "unit": "%"
-          },
-          "THIA": {
-            "label": "Thiamin (B1)",
-            "quantity": 93.74242313333338,
-            "unit": "%"
-          },
-          "RIBF": {
-            "label": "Riboflavin (B2)",
-            "quantity": 190.50879540000003,
-            "unit": "%"
-          },
-          "NIA": {
-            "label": "Niacin (B3)",
-            "quantity": 502.6370450062501,
-            "unit": "%"
-          },
-          "VITB6A": {
-            "label": "Vitamin B6",
-            "quantity": 453.5923700000001,
-            "unit": "%"
-          },
-          "FOLDFE": {
-            "label": "Folate equivalent (total)",
-            "quantity": 38.55535145,
-            "unit": "%"
-          },
-          "VITB12": {
-            "label": "Vitamin B12",
-            "quantity": 94.49841041666669,
-            "unit": "%"
-          },
-          "VITD": {
-            "label": "Vitamin D",
-            "quantity": 302.3949133333334,
-            "unit": "%"
-          },
-          "TOCPHA": {
-            "label": "Vitamin E",
-            "quantity": 42.33528786666667,
-            "unit": "%"
-          },
-          "VITK1": {
-            "label": "Vitamin K",
-            "quantity": 31.751465900000003,
-            "unit": "%"
-          }
-        },
-        "digest": [
-          {
-            "label": "Fat",
-            "tag": "FAT",
-            "schemaOrgTag": "fatContent",
-            "total": 141.15794554400003,
-            "hasRDI": true,
-            "daily": 217.16607006769235,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Saturated",
-                "tag": "FASAT",
-                "schemaOrgTag": "saturatedFatContent",
-                "total": 42.66489832220001,
-                "hasRDI": true,
-                "daily": 213.32449161100004,
-                "unit": "g"
-              },
-              {
-                "label": "Trans",
-                "tag": "FATRN",
-                "schemaOrgTag": "transFatContent",
-                "total": 0.6350293180000002,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Monounsaturated",
-                "tag": "FAMS",
-                "schemaOrgTag": null,
-                "total": 67.05909598080001,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Polyunsaturated",
-                "tag": "FAPU",
-                "schemaOrgTag": null,
-                "total": 29.882665335600002,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Carbs",
-            "tag": "CHOCDF",
-            "schemaOrgTag": "carbohydrateContent",
-            "total": 64.04724264400001,
-            "hasRDI": true,
-            "daily": 21.349080881333336,
-            "unit": "g",
-            "sub": [
-              {
-                "label": "Carbs (net)",
-                "tag": "CHOCDF.net",
-                "schemaOrgTag": null,
-                "total": 64.04724264400001,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Fiber",
-                "tag": "FIBTG",
-                "schemaOrgTag": "fiberContent",
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars",
-                "tag": "SUGAR",
-                "schemaOrgTag": "sugarContent",
-                "total": 28.667037784000005,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              },
-              {
-                "label": "Sugars, added",
-                "tag": "SUGAR.added",
-                "schemaOrgTag": null,
-                "total": 0.0,
-                "hasRDI": false,
-                "daily": 0.0,
-                "unit": "g"
-              }
-            ]
-          },
-          {
-            "label": "Protein",
-            "tag": "PROCNT",
-            "schemaOrgTag": "proteinContent",
-            "total": 204.66087734400003,
-            "hasRDI": true,
-            "daily": 409.32175468800006,
-            "unit": "g"
-          },
-          {
-            "label": "Cholesterol",
-            "tag": "CHOLE",
-            "schemaOrgTag": "cholesterolContent",
-            "total": 1061.4061458,
-            "hasRDI": true,
-            "daily": 353.80204860000003,
-            "unit": "mg"
-          },
-          {
-            "label": "Sodium",
-            "tag": "NA",
-            "schemaOrgTag": "sodiumContent",
-            "total": 3356.5835380000003,
-            "hasRDI": true,
-            "daily": 139.85764741666668,
-            "unit": "mg"
-          },
-          {
-            "label": "Calcium",
-            "tag": "CA",
-            "schemaOrgTag": null,
-            "total": 154.2214058,
-            "hasRDI": true,
-            "daily": 15.42214058,
-            "unit": "mg"
-          },
-          {
-            "label": "Magnesium",
-            "tag": "MG",
-            "schemaOrgTag": null,
-            "total": 217.7243376,
-            "hasRDI": true,
-            "daily": 51.839128,
-            "unit": "mg"
-          },
-          {
-            "label": "Potassium",
-            "tag": "K",
-            "schemaOrgTag": null,
-            "total": 3601.5234178000005,
-            "hasRDI": true,
-            "daily": 76.62815782553193,
-            "unit": "mg"
-          },
-          {
-            "label": "Iron",
-            "tag": "FE",
-            "schemaOrgTag": null,
-            "total": 7.983225712000001,
-            "hasRDI": true,
-            "daily": 44.35125395555556,
-            "unit": "mg"
-          },
-          {
-            "label": "Zinc",
-            "tag": "ZN",
-            "schemaOrgTag": null,
-            "total": 13.517052626000002,
-            "hasRDI": true,
-            "daily": 122.88229660000002,
-            "unit": "mg"
-          },
-          {
-            "label": "Phosphorus",
-            "tag": "P",
-            "schemaOrgTag": null,
-            "total": 1605.7169898000002,
-            "hasRDI": true,
-            "daily": 229.38814140000002,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin A",
-            "tag": "VITA_RAE",
-            "schemaOrgTag": null,
-            "total": 99.79032140000001,
-            "hasRDI": true,
-            "daily": 11.08781348888889,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin C",
-            "tag": "VITC",
-            "schemaOrgTag": null,
-            "total": 3.6287389600000006,
-            "hasRDI": true,
-            "daily": 4.031932177777779,
-            "unit": "mg"
-          },
-          {
-            "label": "Thiamin (B1)",
-            "tag": "THIA",
-            "schemaOrgTag": null,
-            "total": 1.1249090776000004,
-            "hasRDI": true,
-            "daily": 93.74242313333338,
-            "unit": "mg"
-          },
-          {
-            "label": "Riboflavin (B2)",
-            "tag": "RIBF",
-            "schemaOrgTag": null,
-            "total": 2.4766143402000003,
-            "hasRDI": true,
-            "daily": 190.50879540000003,
-            "unit": "mg"
-          },
-          {
-            "label": "Niacin (B3)",
-            "tag": "NIA",
-            "schemaOrgTag": null,
-            "total": 80.42192720100002,
-            "hasRDI": true,
-            "daily": 502.6370450062501,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin B6",
-            "tag": "VITB6A",
-            "schemaOrgTag": null,
-            "total": 5.8967008100000005,
-            "hasRDI": true,
-            "daily": 453.5923700000001,
-            "unit": "mg"
-          },
-          {
-            "label": "Folate equivalent (total)",
-            "tag": "FOLDFE",
-            "schemaOrgTag": null,
-            "total": 154.2214058,
-            "hasRDI": true,
-            "daily": 38.55535145,
-            "unit": "µg"
-          },
-          {
-            "label": "Folate (food)",
-            "tag": "FOLFD",
-            "schemaOrgTag": null,
-            "total": 154.2214058,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Folic acid",
-            "tag": "FOLAC",
-            "schemaOrgTag": null,
-            "total": 0.0,
-            "hasRDI": false,
-            "daily": 0.0,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin B12",
-            "tag": "VITB12",
-            "schemaOrgTag": null,
-            "total": 2.2679618500000003,
-            "hasRDI": true,
-            "daily": 94.49841041666669,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin D",
-            "tag": "VITD",
-            "schemaOrgTag": null,
-            "total": 45.35923700000001,
-            "hasRDI": true,
-            "daily": 302.3949133333334,
-            "unit": "µg"
-          },
-          {
-            "label": "Vitamin E",
-            "tag": "TOCPHA",
-            "schemaOrgTag": null,
-            "total": 6.35029318,
-            "hasRDI": true,
-            "daily": 42.33528786666667,
-            "unit": "mg"
-          },
-          {
-            "label": "Vitamin K",
-            "tag": "VITK1",
-            "schemaOrgTag": null,
-            "total": 38.10175908,
-            "hasRDI": true,
-            "daily": 31.751465900000003,
-            "unit": "µg"
-          }
-        ]
-      },
-      "bookmarked": false,
-      "bought": false
-    }
-  ]
+  }
 }

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
+var recipesRouter = require('./routes/api/v1/recipes');
 
 var app = express();
 
@@ -15,5 +16,6 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
+app.use('/api/v1/recipes', recipesRouter);
 
 module.exports = app;

--- a/migrations/20191012212436-create-recipe.js
+++ b/migrations/20191012212436-create-recipe.js
@@ -11,10 +11,13 @@ module.exports = {
       name: {
         type: Sequelize.STRING
       },
+      foodType: {
+        type: Sequelize.STRING
+      },
       image: {
         type: Sequelize.STRING
       },
-      uri: {
+      url: {
         type: Sequelize.STRING
       },
       calories: {

--- a/migrations/20191013180149-add_yield_to_recipe_model.js
+++ b/migrations/20191013180149-add_yield_to_recipe_model.js
@@ -5,7 +5,7 @@ module.exports = {
     return queryInterface.addColumn(
       'Recipes',
       'yield',
-      Sequelize.STRING
+      Sequelize.FLOAT
     );
   },
 

--- a/models/recipe.js
+++ b/models/recipe.js
@@ -2,10 +2,12 @@
 module.exports = (sequelize, DataTypes) => {
   const Recipe = sequelize.define('Recipe', {
     name: DataTypes.STRING,
+    foodType: DataTypes.STRING,
     image: DataTypes.STRING,
-    uri: DataTypes.STRING,
+    url: DataTypes.STRING,
     calories: DataTypes.FLOAT,
     totalTime: DataTypes.FLOAT,
+    yield: DataTypes.FLOAT,
     ingredients: DataTypes.ARRAY(DataTypes.STRING)
   }, {});
   Recipe.associate = function(models) {

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const router = express.Router();
+const recipe = require('../../../models').Recipe;
+const edamamService = require('../../../services/edamam_service').EdamamService
+
+
+router.get('/food_search', async (req, res, next) => {
+  res.setHeader('Content-Type', 'application/json')
+  let createdRecipes = []
+
+  await recipe.findAll({
+    where: { foodType: req.query.q }
+  })
+    .then(async recipes => {
+      if (recipes.length === 0) {
+        let edamam = await new edamamService(req.query.q);
+
+        await edamam.getRecipes().then(async edamamResponse => {
+          let edamamRecipes = await edamamResponse.hits;
+
+          for (let i = 0; i < edamamRecipes.length; i++) {
+            let result = edamamRecipes[i];
+            await recipe.create({
+              name: result.recipe.label,
+              foodType: req.query.q,
+              image: result.recipe.image,
+              url: result.recipe.url,
+              calories: result.recipe.calories,
+              totalTime: result.recipe.totalTime,
+              yield: result.recipe.yield,
+              ingredients: result.recipe.ingredientLines
+            })
+              .then(async recipe =>
+                createdRecipes.push(recipe)
+              );
+          };
+        });
+        res.status(200).send(createdRecipes)
+        return;
+      };
+      res.status(200).send(recipes)
+    })
+    .catch(async error => {
+      res.status(500).send( {error} )
+    });
+});
+
+module.exports = router;

--- a/services/edamam_service.js
+++ b/services/edamam_service.js
@@ -7,18 +7,18 @@ class EdamamService {
     this.foodType = foodType
   }
 
-  getRecipes() {
-    return axios.get("https://api.edamam.com/search", {
-      params: {
-        q: this.foodType,
-        app_id: id,
-        app_key: key,
-        to: 10,
-        time: '1%2B'
-      }
-    })
-      .then(response => {
-        return response
+  async getRecipes() {
+    const url = 'https://api.edamam.com/search?'
+    const app_id = `app_id=${id}&`
+    const app_key = `app_key=${key}&`
+    const params = `q=${this.foodType}&to=10&time=1%2B`
+
+    return await axios.get(`${url}${app_id}${app_key}${params}`)
+      .then(async response => {
+        return await response.data
+      })
+      .catch(async error => {
+        return error
       })
   }
 }

--- a/tests/recipes/get_food_search_request.spec.js
+++ b/tests/recipes/get_food_search_request.spec.js
@@ -1,0 +1,37 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const recipeResponse = require("../../__fixtures__/chicken_recipes");
+const mockAxios = require('axios');
+const recipe = require('../../models').Recipe;
+
+describe('Recipes API', () => {
+  describe('Food search GET request', () => {
+    beforeEach(async () => {
+      await recipe.destroy({where: {}});
+    });
+    afterEach(async () => {
+      await recipe.destroy({where: {}});
+    });
+
+    test('It returns a list of recipes by food type', () => {
+      mockAxios.get.mockImplementationOnce(() =>
+        Promise.resolve(recipeResponse)
+      );
+
+      return request(app).get('/api/v1/recipes/food_search?q=chicken')
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(response.body.length).toBe(10)
+          expect(Object.keys(response.body[0])).toContain("id")
+          expect(Object.keys(response.body[0])).toContain("name")
+          expect(Object.keys(response.body[0])).toContain("image")
+          expect(Object.keys(response.body[0])).toContain("yield")
+          expect(Object.keys(response.body[0])).toContain("url")
+          expect(Object.keys(response.body[0])).toContain("ingredients")
+          expect(Object.keys(response.body[0])).toContain("calories")
+          expect(Object.keys(response.body[0])).toContain("totalTime")
+        })
+    })
+  })
+})

--- a/tests/services/edamam_service.spec.js
+++ b/tests/services/edamam_service.spec.js
@@ -18,8 +18,9 @@ describe('Edamam Service', () => {
         let hits = response.hits
         expect(Object.keys(hits[0])).toContain("recipe")
         expect(Object.keys(hits[0].recipe)).toContain("label")
-        expect(Object.keys(hits[0].recipe)).toContain("uri")
+        expect(Object.keys(hits[0].recipe)).toContain("url")
         expect(Object.keys(hits[0].recipe)).toContain("image")
+        expect(Object.keys(hits[0].recipe)).toContain("yield")
         expect(Object.keys(hits[0].recipe)).toContain("ingredientLines")
         expect(Object.keys(hits[0].recipe)).toContain("calories")
         expect(Object.keys(hits[0].recipe)).toContain("totalTime")


### PR DESCRIPTION
- Able to send GET request to `'/api/v1/recipes/food_search?q=<food_type>'` with a food type parameter to receive recipes with that food type. If no records are found, a request is made to Edamam API and the response is parsed and saved into the database
- Closes #4 