### PR TITLE
Get time search route

### DIFF
--- a/__fixtures__/time_recipes.json
+++ b/__fixtures__/time_recipes.json
@@ -1,0 +1,6476 @@
+{
+  "data": {
+    "q": "noodles",
+    "from": 0,
+    "to": 10,
+    "params": {
+      "sane": [],
+      "q": [
+        "noodles"
+      ],
+      "app_key": [
+        "042170f2d26ea42fc061e26221087fba"
+      ],
+      "to": [
+        "10"
+      ],
+      "time": [
+        "1-20"
+      ],
+      "app_id": [
+        "671db6f5"
+      ]
+    },
+    "more": true,
+    "count": 1932,
+    "hits": [
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_5c601760f8717e87ce37039e1cdefbd4",
+          "label": "Beef Goulash with Egg Noodles",
+          "image": "https://www.edamam.com/web-img/f92/f9224a05c0f8c4c3c99a5fe69fadb741.jpg",
+          "source": "Martha Stewart",
+          "url": "http://www.marthastewart.com/1090880/beef-goulash-egg-noodles",
+          "shareAs": "http://www.edamam.com/recipe/beef-goulash-with-egg-noodles-5c601760f8717e87ce37039e1cdefbd4/noodles",
+          "yield": 4.0,
+          "dietLabels": [
+            "Balanced"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [],
+          "ingredientLines": [
+            "8 ounces egg noodles",
+            "2 tablespoons unsalted butter",
+            "Coarse salt and freshly ground pepper",
+            "1/2 recipe Beef Goulash with Potatoes",
+            "Sour cream and chopped fresh parsley, for serving"
+          ],
+          "ingredients": [
+            {
+              "text": "8 ounces egg noodles",
+              "weight": 226.796185
+            },
+            {
+              "text": "2 tablespoons unsalted butter",
+              "weight": 28.4
+            },
+            {
+              "text": "Coarse salt and freshly ground pepper",
+              "weight": 0.0
+            },
+            {
+              "text": "Coarse salt and freshly ground pepper",
+              "weight": 1.085088555
+            },
+            {
+              "text": "1/2 recipe Beef Goulash with Potatoes",
+              "weight": 106.5
+            }
+          ],
+          "calories": 1159.25392267305,
+          "totalWeight": 362.78127355500004,
+          "totalTime": 10.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 1159.25392267305,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 33.236214500893,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 17.3075014156856,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 1.0692976728499999,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 8.81960104062145,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 3.9394934061289,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 180.95414518042253,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 10.101801509415,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 5.118452844752,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 34.6197804968645,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 251.56879540000003,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 57.358216561000006,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 103.78160704865002,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 158.46028872905003,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1022.98451829595,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 10.036269117190502,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 4.7018093058045,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 615.8142457669002,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 233.10432535984995,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 20.9805,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 2.6573926716894,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.011840907499,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 20.168236598133653,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.80806436729505,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 857.22234955435,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 83.84735870435,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 455.8603318500001,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 0.7059889365,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 41.98758035,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 1.5199608054720002,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 6.921770889534999,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 57.96269613365251,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 51.13263769368154,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 86.53750707842799,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 60.31804839347418,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 40.40720603766,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 69.239560993729,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 83.85626513333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 2.389925690041667,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 10.378160704865001,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 37.728640173583344,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 21.76562804885,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 55.75705065105834,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 42.74372096185909,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 87.97346368098574,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 25.90048059553888,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 23.311666666666664,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 221.44938930745,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 77.83391596146154,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 126.05147873833533,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 62.15879748423462,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 214.30558738858747,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 29.416205687500003,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 279.9172023333333,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 10.133072036480002,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 5.768142407945833,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 33.236214500893,
+              "hasRDI": true,
+              "daily": 51.13263769368154,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 17.3075014156856,
+                  "hasRDI": true,
+                  "daily": 86.53750707842799,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 1.0692976728499999,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 8.81960104062145,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 3.9394934061289,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 180.95414518042253,
+              "hasRDI": true,
+              "daily": 60.31804839347418,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 170.85234367100753,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 10.101801509415,
+                  "hasRDI": true,
+                  "daily": 40.40720603766,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 5.118452844752,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 34.6197804968645,
+              "hasRDI": true,
+              "daily": 69.239560993729,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 251.56879540000003,
+              "hasRDI": true,
+              "daily": 83.85626513333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 57.358216561000006,
+              "hasRDI": true,
+              "daily": 2.389925690041667,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 103.78160704865002,
+              "hasRDI": true,
+              "daily": 10.378160704865001,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 158.46028872905003,
+              "hasRDI": true,
+              "daily": 37.728640173583344,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1022.98451829595,
+              "hasRDI": true,
+              "daily": 21.76562804885,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 10.036269117190502,
+              "hasRDI": true,
+              "daily": 55.75705065105834,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 4.7018093058045,
+              "hasRDI": true,
+              "daily": 42.74372096185909,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 615.8142457669002,
+              "hasRDI": true,
+              "daily": 87.97346368098574,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 233.10432535984995,
+              "hasRDI": true,
+              "daily": 25.90048059553888,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 20.9805,
+              "hasRDI": true,
+              "daily": 23.311666666666664,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 2.6573926716894,
+              "hasRDI": true,
+              "daily": 221.44938930745,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.011840907499,
+              "hasRDI": true,
+              "daily": 77.83391596146154,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 20.168236598133653,
+              "hasRDI": true,
+              "daily": 126.05147873833533,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.80806436729505,
+              "hasRDI": true,
+              "daily": 62.15879748423462,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 857.22234955435,
+              "hasRDI": true,
+              "daily": 214.30558738858747,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 83.84735870435,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 455.8603318500001,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.7059889365,
+              "hasRDI": true,
+              "daily": 29.416205687500003,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 41.98758035,
+              "hasRDI": true,
+              "daily": 279.9172023333333,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 1.5199608054720002,
+              "hasRDI": true,
+              "daily": 10.133072036480002,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 6.921770889534999,
+              "hasRDI": true,
+              "daily": 5.768142407945833,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_5a350ec42d6c9f1c34e97d4e1429310f",
+          "label": "Mint and Scallion Soba Noodles recipes",
+          "image": "https://www.edamam.com/web-img/f98/f98fb8d27fbf2b2e7be8587b299f93f6",
+          "source": "Epicurious",
+          "url": "http://www.epicurious.com/recipes/food/views/Mint-and-Scallion-Soba-Noodles-105128",
+          "shareAs": "http://www.edamam.com/recipe/mint-and-scallion-soba-noodles-recipes-5a350ec42d6c9f1c34e97d4e1429310f/noodles",
+          "yield": 6.0,
+          "dietLabels": [
+            "Low-Fat"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Vegan",
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Gluten",
+            "Wheat"
+          ],
+          "ingredientLines": [
+            "12 oz dried soba noodles (Japanese buckwheat noodles)",
+            "1/3 cup rice vinegar (not seasoned)",
+            "1 tablespoon vegetable oil",
+            "1 tablespoon soy sauce",
+            "1 1/4 teaspoons sugar",
+            "3/4 teaspoon salt",
+            "1/2 cup chopped fresh mint",
+            "1 1/2 cups thinly sliced scallions (1 1/2 bunches)"
+          ],
+          "ingredients": [
+            {
+              "text": "12 oz dried soba noodles (Japanese buckwheat noodles)",
+              "weight": 340.1942775
+            },
+            {
+              "text": "1/3 cup rice vinegar (not seasoned)",
+              "weight": 79.33333333333333
+            },
+            {
+              "text": "1 tablespoon vegetable oil",
+              "weight": 14.0
+            },
+            {
+              "text": "1 tablespoon soy sauce",
+              "weight": 16.0
+            },
+            {
+              "text": "1 1/4 teaspoons sugar",
+              "weight": 5.25
+            },
+            {
+              "text": "3/4 teaspoon salt",
+              "weight": 4.5
+            },
+            {
+              "text": "1/2 cup chopped fresh mint",
+              "weight": 45.6
+            },
+            {
+              "text": "1 1/2 cups thinly sliced scallions (1 1/2 bunches)",
+              "weight": 169.5
+            }
+          ],
+          "calories": 1384.1942724000003,
+          "totalWeight": 669.8776108333334,
+          "totalTime": 20.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 1384.1942724000003,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 17.161509370250002,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 1.5272202174000002,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.10738000000000002,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 10.779344413375002,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 3.4893214105,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 276.1987132038334,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 7.6358,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 9.284583333333334,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 5.2395,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 54.8244271045,
+              "unit": "g"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3615.6578444666666,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 341.944497125,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 398.4458969583333,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1605.2492459666666,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 17.364990492500002,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 7.123070478583333,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 983.9017981833333,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 177.31799999999998,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 37.930800000000005,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.7670055320000002,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 0.6850500607500001,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 12.59375930775,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 1.015589266,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 362.7165665,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 362.7165665,
+              "unit": "µg"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 3.9842500000000007,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 350.865,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 69.20971362000002,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 26.402322108076923,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 7.636101087000002,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 92.06623773461114,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 30.5432,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 109.648854209,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 150.6524101861111,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 34.194449712499996,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 94.86807070436508,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 34.154239275886525,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 96.4721694027778,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 64.7551861689394,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 140.5573997404762,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 19.701999999999998,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 42.14533333333334,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 147.25046100000003,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 52.69615851923078,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 78.7109956734375,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 78.12225123076924,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 90.679141625,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 26.56166666666667,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 292.3875,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 17.161509370250002,
+              "hasRDI": true,
+              "daily": 26.402322108076923,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 1.5272202174000002,
+                  "hasRDI": true,
+                  "daily": 7.636101087000002,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.10738000000000002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 10.779344413375002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 3.4893214105,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 276.1987132038334,
+              "hasRDI": true,
+              "daily": 92.06623773461114,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 268.5629132038334,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 7.6358,
+                  "hasRDI": true,
+                  "daily": 30.5432,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 9.284583333333334,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 5.2395,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 54.8244271045,
+              "hasRDI": true,
+              "daily": 109.648854209,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3615.6578444666666,
+              "hasRDI": true,
+              "daily": 150.6524101861111,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 341.944497125,
+              "hasRDI": true,
+              "daily": 34.194449712499996,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 398.4458969583333,
+              "hasRDI": true,
+              "daily": 94.86807070436508,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1605.2492459666666,
+              "hasRDI": true,
+              "daily": 34.154239275886525,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 17.364990492500002,
+              "hasRDI": true,
+              "daily": 96.4721694027778,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 7.123070478583333,
+              "hasRDI": true,
+              "daily": 64.7551861689394,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 983.9017981833333,
+              "hasRDI": true,
+              "daily": 140.5573997404762,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 177.31799999999998,
+              "hasRDI": true,
+              "daily": 19.701999999999998,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 37.930800000000005,
+              "hasRDI": true,
+              "daily": 42.14533333333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.7670055320000002,
+              "hasRDI": true,
+              "daily": 147.25046100000003,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 0.6850500607500001,
+              "hasRDI": true,
+              "daily": 52.69615851923078,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 12.59375930775,
+              "hasRDI": true,
+              "daily": 78.7109956734375,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 1.015589266,
+              "hasRDI": true,
+              "daily": 78.12225123076924,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 362.7165665,
+              "hasRDI": true,
+              "daily": 90.679141625,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 362.7165665,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 3.9842500000000007,
+              "hasRDI": true,
+              "daily": 26.56166666666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 350.865,
+              "hasRDI": true,
+              "daily": 292.3875,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_5e18f55ad0b6974458ad5f63e7d307e2",
+          "label": "Sesame Noodles",
+          "image": "https://www.edamam.com/web-img/62b/62b351dc2b7728ca775bef7ddf9d00f5.jpg",
+          "source": "Honest Cooking",
+          "url": "http://honestcooking.com/sesame-noodles-recipe/",
+          "shareAs": "http://www.edamam.com/recipe/sesame-noodles-5e18f55ad0b6974458ad5f63e7d307e2/noodles",
+          "yield": 4.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1 package of chinese noodles cooked and drained (you can also use spaghetti)",
+            "¼ cup low-sodium soy sauce",
+            "2 tbsp sugar",
+            "4 cloves garlic, minced",
+            "2 tbsp rice vinegar",
+            "3 tbsp pure sesame oil",
+            "½ tsp hot chili oil",
+            "4 tbsp canola oil",
+            "2 scallions, sliced thin",
+            "2 tbsp sesame seeds"
+          ],
+          "ingredients": [
+            {
+              "text": "1 package of chinese noodles cooked and drained (you can also use spaghetti)",
+              "weight": 453.0
+            },
+            {
+              "text": "¼ cup low-sodium soy sauce",
+              "weight": 63.75
+            },
+            {
+              "text": "2 tbsp sugar",
+              "weight": 25.2
+            },
+            {
+              "text": "4 cloves garlic, minced",
+              "weight": 12.0
+            },
+            {
+              "text": "2 tbsp rice vinegar",
+              "weight": 29.8
+            },
+            {
+              "text": "3 tbsp pure sesame oil",
+              "weight": 40.8
+            },
+            {
+              "text": "½ tsp hot chili oil",
+              "weight": 2.25
+            },
+            {
+              "text": "4 tbsp canola oil",
+              "weight": 56.0
+            },
+            {
+              "text": "2 scallions, sliced thin",
+              "weight": 15.0
+            },
+            {
+              "text": "2 tbsp sesame seeds",
+              "weight": 18.0
+            }
+          ],
+          "calories": 2821.2775,
+          "totalWeight": 715.8,
+          "totalTime": 20.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2821.2775,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 115.11064999999999,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 12.628574999999998,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.23008750000000003,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 57.23926500000001,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 40.009330000000006,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 376.314805,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 17.708250000000003,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 38.098870000000005,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 25.1496,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 69.069675,
+              "unit": "g"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 2328.1730000000002,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 324.31500000000005,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 353.5555,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1409.45,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 9.816165,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 8.489125,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1100.317,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 7.5,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 6.564,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 0.6078300000000001,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 0.49924799999999997,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 9.403199999999998,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 1.04481,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 137.01,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 137.01,
+              "unit": "µg"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 11.638425000000002,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 78.78805,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 141.063875,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 177.09330769230766,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 63.14287499999999,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 125.43826833333333,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 70.83300000000001,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 138.13935,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 97.00720833333334,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 32.43150000000001,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 84.17988095238096,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 29.988297872340425,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 54.53425,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 77.17386363636363,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 157.18814285714285,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 0.8333333333333334,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 7.293333333333333,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 50.65250000000001,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 38.4036923076923,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 58.76999999999999,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 80.36999999999999,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 34.2525,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 77.58950000000002,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 65.65670833333334,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 115.11064999999999,
+              "hasRDI": true,
+              "daily": 177.09330769230766,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 12.628574999999998,
+                  "hasRDI": true,
+                  "daily": 63.14287499999999,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.23008750000000003,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 57.23926500000001,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 40.009330000000006,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 376.314805,
+              "hasRDI": true,
+              "daily": 125.43826833333333,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 358.60655499999996,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 17.708250000000003,
+                  "hasRDI": true,
+                  "daily": 70.83300000000001,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 38.098870000000005,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 25.1496,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 69.069675,
+              "hasRDI": true,
+              "daily": 138.13935,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 2328.1730000000002,
+              "hasRDI": true,
+              "daily": 97.00720833333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 324.31500000000005,
+              "hasRDI": true,
+              "daily": 32.43150000000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 353.5555,
+              "hasRDI": true,
+              "daily": 84.17988095238096,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1409.45,
+              "hasRDI": true,
+              "daily": 29.988297872340425,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 9.816165,
+              "hasRDI": true,
+              "daily": 54.53425,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 8.489125,
+              "hasRDI": true,
+              "daily": 77.17386363636363,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1100.317,
+              "hasRDI": true,
+              "daily": 157.18814285714285,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 7.5,
+              "hasRDI": true,
+              "daily": 0.8333333333333334,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 6.564,
+              "hasRDI": true,
+              "daily": 7.293333333333333,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 0.6078300000000001,
+              "hasRDI": true,
+              "daily": 50.65250000000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 0.49924799999999997,
+              "hasRDI": true,
+              "daily": 38.4036923076923,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 9.403199999999998,
+              "hasRDI": true,
+              "daily": 58.76999999999999,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 1.04481,
+              "hasRDI": true,
+              "daily": 80.36999999999999,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 137.01,
+              "hasRDI": true,
+              "daily": 34.2525,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 137.01,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 11.638425000000002,
+              "hasRDI": true,
+              "daily": 77.58950000000002,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 78.78805,
+              "hasRDI": true,
+              "daily": 65.65670833333334,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_27635cdbe820b9c60663f9c2f3fa1b85",
+          "label": "Herbed Egg Noodles",
+          "image": "https://www.edamam.com/web-img/805/805762845be2c35aaee187fe3715f0a2.jpg",
+          "source": "PBS Food",
+          "url": "http://www.pbs.org/food/recipes/herbed-egg-noodles/",
+          "shareAs": "http://www.edamam.com/recipe/herbed-egg-noodles-27635cdbe820b9c60663f9c2f3fa1b85/noodles",
+          "yield": 4.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [],
+          "ingredientLines": [
+            "8 ounces egg noodles",
+            "Coarse salt and ground pepper",
+            "1/4 cup chopped fresh parsley",
+            "1 tablespoon chopped fresh thyme leaves",
+            "1 tablespoon butter"
+          ],
+          "ingredients": [
+            {
+              "text": "8 ounces egg noodles",
+              "weight": 226.796185
+            },
+            {
+              "text": "Coarse salt and ground pepper",
+              "weight": 0.0
+            },
+            {
+              "text": "Coarse salt and ground pepper",
+              "weight": 0.7904885549996197
+            },
+            {
+              "text": "1/4 cup chopped fresh parsley",
+              "weight": 15.0
+            },
+            {
+              "text": "1 tablespoon chopped fresh thyme leaves",
+              "weight": 7.499999999873198
+            },
+            {
+              "text": "1 tablespoon butter",
+              "weight": 14.2
+            }
+          ],
+          "calories": 987.6704766729209,
+          "totalWeight": 264.28667355487283,
+          "totalTime": 15.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 987.6704766729209,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 21.857640540890856,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 10.036279583685003,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.60382167285,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 5.880636946621345,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 3.517152298128222,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 164.93492848039128,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 9.229267709397153,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 4.404847404751998,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 33.17967155685742,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 221.03879540000003,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 58.422296560988514,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 137.36352904813478,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 152.67752272884647,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 696.0712842951729,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 11.412873457168338,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 4.672923565802201,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 567.8857777667652,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 216.8967833595481,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 31.957499999796987,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 2.5876645036893393,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.0224276274984023,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 19.37014532013134,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.5322060812946077,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 865.8812675542929,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 92.50627670429289,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 455.8603318500001,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 0.6818489365000001,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 33.467580350000006,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 1.289306965471996,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 249.42201068953437,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 49.383523833646045,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 33.62713929367824,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 50.18139791842502,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 54.97830949346376,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 36.91707083758861,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 66.35934311371484,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 73.67959846666668,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 2.4342623567078547,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 13.73635290481348,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 36.351791125915824,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 14.810027325429209,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 63.404852539824105,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 42.48112332547455,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 81.12653968096646,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 24.099642595505344,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 35.508333333107764,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 215.63870864077828,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 78.64827903833864,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 121.06340825082087,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 40.93892933035443,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 216.47031688857322,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 28.41037235416667,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 223.11720233333338,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 8.595379769813308,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 207.85167557461196,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 21.857640540890856,
+              "hasRDI": true,
+              "daily": 33.62713929367824,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 10.036279583685003,
+                  "hasRDI": true,
+                  "daily": 50.18139791842502,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.60382167285,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 5.880636946621345,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 3.517152298128222,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 164.93492848039128,
+              "hasRDI": true,
+              "daily": 54.97830949346376,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 155.70566077099411,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 9.229267709397153,
+                  "hasRDI": true,
+                  "daily": 36.91707083758861,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 4.404847404751998,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 33.17967155685742,
+              "hasRDI": true,
+              "daily": 66.35934311371484,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 221.03879540000003,
+              "hasRDI": true,
+              "daily": 73.67959846666668,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 58.422296560988514,
+              "hasRDI": true,
+              "daily": 2.4342623567078547,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 137.36352904813478,
+              "hasRDI": true,
+              "daily": 13.73635290481348,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 152.67752272884647,
+              "hasRDI": true,
+              "daily": 36.351791125915824,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 696.0712842951729,
+              "hasRDI": true,
+              "daily": 14.810027325429209,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 11.412873457168338,
+              "hasRDI": true,
+              "daily": 63.404852539824105,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 4.672923565802201,
+              "hasRDI": true,
+              "daily": 42.48112332547455,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 567.8857777667652,
+              "hasRDI": true,
+              "daily": 81.12653968096646,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 216.8967833595481,
+              "hasRDI": true,
+              "daily": 24.099642595505344,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 31.957499999796987,
+              "hasRDI": true,
+              "daily": 35.508333333107764,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 2.5876645036893393,
+              "hasRDI": true,
+              "daily": 215.63870864077828,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.0224276274984023,
+              "hasRDI": true,
+              "daily": 78.64827903833864,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 19.37014532013134,
+              "hasRDI": true,
+              "daily": 121.06340825082087,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.5322060812946077,
+              "hasRDI": true,
+              "daily": 40.93892933035443,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 865.8812675542929,
+              "hasRDI": true,
+              "daily": 216.47031688857322,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 92.50627670429289,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 455.8603318500001,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.6818489365000001,
+              "hasRDI": true,
+              "daily": 28.41037235416667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 33.467580350000006,
+              "hasRDI": true,
+              "daily": 223.11720233333338,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 1.289306965471996,
+              "hasRDI": true,
+              "daily": 8.595379769813308,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 249.42201068953437,
+              "hasRDI": true,
+              "daily": 207.85167557461196,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_4cdb53a6ca0900df52cea0969b1b1df2",
+          "label": "Late-Night Asian Noodles recipes",
+          "image": "https://www.edamam.com/web-img/0c4/0c49bb3b3e4c705f614c955db1287f54",
+          "source": "Chowhound",
+          "url": "http://www.chowhound.com/recipes/late-night-asian-noodles-11033",
+          "shareAs": "http://www.edamam.com/recipe/late-night-asian-noodles-recipes-4cdb53a6ca0900df52cea0969b1b1df2/noodles",
+          "yield": 2.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Vegetarian",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Soy",
+            "Sulfites",
+            "FODMAP"
+          ],
+          "ingredientLines": [
+            "4 cups boiling water",
+            "2 (3-ounce) packages ramen noodles (without seasoning packets)",
+            "2 cups prepared coleslaw (vegetables only)",
+            "3 tablespoons crunchy peanut butter",
+            "4 teaspoons freshly squeezed lime juice",
+            "1 tablespoon chile-garlic paste (such as Huy Fong)"
+          ],
+          "ingredients": [
+            {
+              "text": "4 cups boiling water",
+              "weight": 948.0
+            },
+            {
+              "text": "2 (3-ounce) packages ramen noodles (without seasoning packets)",
+              "weight": 5.8
+            },
+            {
+              "text": "2 cups prepared coleslaw (vegetables only)",
+              "weight": 382.0
+            },
+            {
+              "text": "3 tablespoons crunchy peanut butter",
+              "weight": 48.0
+            },
+            {
+              "text": "4 teaspoons freshly squeezed lime juice",
+              "weight": 20.533333334374806
+            },
+            {
+              "text": "1 tablespoon chile-garlic paste (such as Huy Fong)",
+              "weight": 9.374999999841497
+            }
+          ],
+          "calories": 905.9033333335302,
+          "totalWeight": 1413.7083333342164,
+          "totalTime": 5.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 905.9033333335302,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 63.58484333333337,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 11.540546166666685,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.18111,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 23.015840666666712,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 26.600772916666532,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 73.6385241667404,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 10.048958333335122,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 52.559728333342534,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 15.14121250000141,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 15.280000000000001,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 930.3844166666732,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 171.96516666679028,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 125.92891666671353,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 825.3295000007081,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 2.029022499999305,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 1.9100016666670878,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 250.7759166667443,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 111.92866666661142,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 75.42127500008468,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 0.20918733333347955,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 0.1944925000000199,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 7.53972033333284,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.6969641666662605,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 55.53958333340102,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 48.57958333340102,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 4.06,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 0.052700000000000004,
+              "unit": "µg"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 6.682180833334531,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 272.93389999998413,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 45.29516666667651,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 97.82283589743595,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 57.70273083333342,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 24.5461747222468,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 40.19583333334049,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 30.28242500000282,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 5.093333333333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 38.76601736111138,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 17.196516666679027,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 29.983075396836558,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 17.56020212767464,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 11.272347222218361,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 17.363651515155343,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 35.825130952392044,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 12.436518518512381,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 83.80141666676076,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 17.432277777789963,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 14.96096153846307,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 47.12325208333025,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 53.61262820509696,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 13.884895833350253,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 2.1958333333333337,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 44.54787222223021,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 227.44491666665346,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 63.58484333333337,
+              "hasRDI": true,
+              "daily": 97.82283589743595,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 11.540546166666685,
+                  "hasRDI": true,
+                  "daily": 57.70273083333342,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.18111,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 23.015840666666712,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 26.600772916666532,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 73.6385241667404,
+              "hasRDI": true,
+              "daily": 24.5461747222468,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 63.589565833405274,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 10.048958333335122,
+                  "hasRDI": true,
+                  "daily": 40.19583333334049,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 52.559728333342534,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 15.14121250000141,
+              "hasRDI": true,
+              "daily": 30.28242500000282,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 15.280000000000001,
+              "hasRDI": true,
+              "daily": 5.093333333333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 930.3844166666732,
+              "hasRDI": true,
+              "daily": 38.76601736111138,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 171.96516666679028,
+              "hasRDI": true,
+              "daily": 17.196516666679027,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 125.92891666671353,
+              "hasRDI": true,
+              "daily": 29.983075396836558,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 825.3295000007081,
+              "hasRDI": true,
+              "daily": 17.56020212767464,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 2.029022499999305,
+              "hasRDI": true,
+              "daily": 11.272347222218361,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 1.9100016666670878,
+              "hasRDI": true,
+              "daily": 17.363651515155343,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 250.7759166667443,
+              "hasRDI": true,
+              "daily": 35.825130952392044,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 111.92866666661142,
+              "hasRDI": true,
+              "daily": 12.436518518512381,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 75.42127500008468,
+              "hasRDI": true,
+              "daily": 83.80141666676076,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 0.20918733333347955,
+              "hasRDI": true,
+              "daily": 17.432277777789963,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 0.1944925000000199,
+              "hasRDI": true,
+              "daily": 14.96096153846307,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 7.53972033333284,
+              "hasRDI": true,
+              "daily": 47.12325208333025,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.6969641666662605,
+              "hasRDI": true,
+              "daily": 53.61262820509696,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 55.53958333340102,
+              "hasRDI": true,
+              "daily": 13.884895833350253,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 48.57958333340102,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 4.06,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.052700000000000004,
+              "hasRDI": true,
+              "daily": 2.1958333333333337,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 6.682180833334531,
+              "hasRDI": true,
+              "daily": 44.54787222223021,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 272.93389999998413,
+              "hasRDI": true,
+              "daily": 227.44491666665346,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_d461220222c1b9854fbe3adff73db155",
+          "label": "Dinner Tonight: Cold Sesame Noodles Recipe",
+          "image": "https://www.edamam.com/web-img/9ba/9baf1462d71e62d7fe35bb1aebe98698.jpg",
+          "source": "Serious Eats",
+          "url": "http://www.seriouseats.com/recipes/2011/06/dinner-tonight-cold-sesame-noodles-recipe.html",
+          "shareAs": "http://www.edamam.com/recipe/dinner-tonight-cold-sesame-noodles-recipe-d461220222c1b9854fbe3adff73db155/noodles",
+          "yield": 4.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites",
+            "FODMAP"
+          ],
+          "ingredientLines": [
+            "1 pound Chinese egg noodles, such as lo mein",
+            "1 teaspoon toasted sesame oil",
+            "6 tablespoons tahini (sesame paste)",
+            "3/4 cup water, plus more as needed",
+            "1 tablespoon rice vinegar",
+            "4 tablespoons soy sauce",
+            "1 1/2 teaspoons sugar",
+            "2 cloves garlic, minced",
+            "1 scallion, thinly sliced",
+            "1 tablespoon minced ginger",
+            "Sriracha hot sauce or chili oil (to taste)"
+          ],
+          "ingredients": [
+            {
+              "text": "1 pound Chinese egg noodles, such as lo mein",
+              "weight": 453.59237
+            },
+            {
+              "text": "1 teaspoon toasted sesame oil",
+              "weight": 4.5
+            },
+            {
+              "text": "6 tablespoons tahini (sesame paste)",
+              "weight": 90.0
+            },
+            {
+              "text": "3/4 cup water, plus more as needed",
+              "weight": 177.75
+            },
+            {
+              "text": "1 tablespoon rice vinegar",
+              "weight": 14.9
+            },
+            {
+              "text": "4 tablespoons soy sauce",
+              "weight": 64.0
+            },
+            {
+              "text": "1 1/2 teaspoons sugar",
+              "weight": 6.300000000000001
+            },
+            {
+              "text": "2 cloves garlic, minced",
+              "weight": 6.0
+            },
+            {
+              "text": "1 scallion, thinly sliced",
+              "weight": 15.0
+            },
+            {
+              "text": "1 tablespoon minced ginger",
+              "weight": 6.0
+            },
+            {
+              "text": "Sriracha hot sauce or chili oil (to taste)",
+              "weight": 0.0
+            },
+            {
+              "text": "Sriracha hot sauce or chili oil (to taste)",
+              "weight": 0.0
+            },
+            {
+              "text": "Sriracha hot sauce or chili oil (to taste)",
+              "weight": 0.0
+            },
+            {
+              "text": "Sriracha hot sauce or chili oil (to taste)",
+              "weight": 0.0
+            }
+          ],
+          "calories": 2396.5977008,
+          "totalWeight": 838.04237,
+          "totalTime": 15.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2396.5977008,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 73.491801228,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 12.836529966000002,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.27669134570000004,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 25.807546472399995,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 29.3250144447,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 355.9569820990001,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 24.486548210000006,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 16.029396556000005,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 6.287400000000002,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 85.50357959200001,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 381.01759080000005,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3725.9453977000003,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 592.1868295,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 404.9500746,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1848.5493828000003,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 27.539674037000008,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 13.592168504,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1875.5636117000001,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 87.31070290000001,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 4.992,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 6.2800715521,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 2.4854404962000003,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 44.51898207190001,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 1.3014295192,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 1785.8917690000003,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 239.1417873,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 911.7206637000002,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 1.3154178730000001,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 49.895160700000005,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 2.069191769,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 34.037961849999995,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 119.82988504,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 113.06430958153847,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 64.18264983000002,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 118.65232736633337,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 97.94619284000002,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 171.00715918400002,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 127.00586360000001,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 155.2477249041667,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 59.21868295,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 96.41668442857143,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 39.3308379319149,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 152.99818909444448,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 123.56516821818182,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 267.9376588142857,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 9.701189211111112,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 5.546666666666667,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 523.3392960083333,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 191.1877304769231,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 278.24363794937506,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 100.10996301538461,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 446.4729422500001,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 54.80907804166667,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 332.6344046666667,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 13.794611793333335,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 28.36496820833333,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 73.491801228,
+              "hasRDI": true,
+              "daily": 113.06430958153847,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 12.836529966000002,
+                  "hasRDI": true,
+                  "daily": 64.18264983000002,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.27669134570000004,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 25.807546472399995,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 29.3250144447,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 355.9569820990001,
+              "hasRDI": true,
+              "daily": 118.65232736633337,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 331.47043388900005,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 24.486548210000006,
+                  "hasRDI": true,
+                  "daily": 97.94619284000002,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 16.029396556000005,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 6.287400000000002,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 85.50357959200001,
+              "hasRDI": true,
+              "daily": 171.00715918400002,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 381.01759080000005,
+              "hasRDI": true,
+              "daily": 127.00586360000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3725.9453977000003,
+              "hasRDI": true,
+              "daily": 155.2477249041667,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 592.1868295,
+              "hasRDI": true,
+              "daily": 59.21868295,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 404.9500746,
+              "hasRDI": true,
+              "daily": 96.41668442857143,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1848.5493828000003,
+              "hasRDI": true,
+              "daily": 39.3308379319149,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 27.539674037000008,
+              "hasRDI": true,
+              "daily": 152.99818909444448,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 13.592168504,
+              "hasRDI": true,
+              "daily": 123.56516821818182,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1875.5636117000001,
+              "hasRDI": true,
+              "daily": 267.9376588142857,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 87.31070290000001,
+              "hasRDI": true,
+              "daily": 9.701189211111112,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 4.992,
+              "hasRDI": true,
+              "daily": 5.546666666666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 6.2800715521,
+              "hasRDI": true,
+              "daily": 523.3392960083333,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 2.4854404962000003,
+              "hasRDI": true,
+              "daily": 191.1877304769231,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 44.51898207190001,
+              "hasRDI": true,
+              "daily": 278.24363794937506,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 1.3014295192,
+              "hasRDI": true,
+              "daily": 100.10996301538461,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 1785.8917690000003,
+              "hasRDI": true,
+              "daily": 446.4729422500001,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 239.1417873,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 911.7206637000002,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 1.3154178730000001,
+              "hasRDI": true,
+              "daily": 54.80907804166667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 49.895160700000005,
+              "hasRDI": true,
+              "daily": 332.6344046666667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 2.069191769,
+              "hasRDI": true,
+              "daily": 13.794611793333335,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 34.037961849999995,
+              "hasRDI": true,
+              "daily": 28.36496820833333,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_b53e78802eacd13eb52ded3639bd59ec",
+          "label": "Simple Sesame Noodles recipes",
+          "image": "https://www.edamam.com/web-img/67e/67ee4047e640d58526f9c637a6fcd893",
+          "source": "Pioneer Woman",
+          "url": "http://thepioneerwoman.com/cooking/simple-sesame-noodles/",
+          "shareAs": "http://www.edamam.com/recipe/simple-sesame-noodles-recipes-b53e78802eacd13eb52ded3639bd59ec/noodles",
+          "yield": 8.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [],
+          "ingredientLines": [
+            "12 ounces, fluid Thin Noodles, Cooked And Drained",
+            "1/4 cup Soy Sauce",
+            "2 Tablespoons Sugar",
+            "4 cloves Garlic, Minced",
+            "2 Tablespoons Rice Vinegar",
+            "3 Tablespoons Pure Sesame Oil",
+            "1/2 teaspoon Hot Chili Oil",
+            "4 Tablespoons Canola Oil",
+            "4 whole Green Onions, Sliced Thin"
+          ],
+          "ingredients": [
+            {
+              "text": "12 ounces, fluid Thin Noodles, Cooked And Drained",
+              "weight": 340.1942775
+            },
+            {
+              "text": "1/4 cup Soy Sauce",
+              "weight": 63.75
+            },
+            {
+              "text": "2 Tablespoons Sugar",
+              "weight": 25.2
+            },
+            {
+              "text": "4 cloves Garlic, Minced",
+              "weight": 12.0
+            },
+            {
+              "text": "2 Tablespoons Rice Vinegar",
+              "weight": 29.8
+            },
+            {
+              "text": "3 Tablespoons Pure Sesame Oil",
+              "weight": 40.8
+            },
+            {
+              "text": "1/2 teaspoon Hot Chili Oil",
+              "weight": 2.25
+            },
+            {
+              "text": "4 Tablespoons Canola Oil",
+              "weight": 56.0
+            },
+            {
+              "text": "4 whole Green Onions, Sliced Thin",
+              "weight": 30.0
+            }
+          ],
+          "calories": 2346.1035256000005,
+          "totalWeight": 599.9942775,
+          "totalTime": 20.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2346.1035256000005,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 114.63500092100001,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 14.164822474500001,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.43760600927500004,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 57.3806223543,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 38.154043333525,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 276.97541657424995,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 12.7684111575,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 32.631172417,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 25.1496,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 54.672959694,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 285.7631931,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3580.9162982750004,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 185.465497125,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 253.78568095000003,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1239.4065371,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 15.235705527750003,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 7.3480551279999995,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 956.3452087750002,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 72.83302717500001,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 9.384,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 3.9159386640750005,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.5964031221500001,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 30.173544053925003,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.9956696394000001,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 1287.20382675,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 127.141340475,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 683.7904977750001,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 0.98656340475,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 37.421370525,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 12.17496882675,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 111.0860213875,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 117.30517628000003,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 176.36153987846154,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 70.82411237250001,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 92.3251388580833,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 51.07364463,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 109.345919388,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 95.25439770000001,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 149.20484576145836,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 18.5465497125,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 60.42516213095239,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 26.37035185319149,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 84.64280848750002,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 66.80050116363635,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 136.62074411071433,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 8.092558575000002,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 10.426666666666668,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 326.3282220062501,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 122.80024016538462,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 188.58465033703126,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 76.58997226153846,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 321.8009566875,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 41.10680853125,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 249.4758035,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 81.16645884500001,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 92.57168448958333,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 114.63500092100001,
+              "hasRDI": true,
+              "daily": 176.36153987846154,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 14.164822474500001,
+                  "hasRDI": true,
+                  "daily": 70.82411237250001,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.43760600927500004,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 57.3806223543,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 38.154043333525,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 276.97541657424995,
+              "hasRDI": true,
+              "daily": 92.3251388580833,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 264.20700541674995,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 12.7684111575,
+                  "hasRDI": true,
+                  "daily": 51.07364463,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 32.631172417,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 25.1496,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 54.672959694,
+              "hasRDI": true,
+              "daily": 109.345919388,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 285.7631931,
+              "hasRDI": true,
+              "daily": 95.25439770000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3580.9162982750004,
+              "hasRDI": true,
+              "daily": 149.20484576145836,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 185.465497125,
+              "hasRDI": true,
+              "daily": 18.5465497125,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 253.78568095000003,
+              "hasRDI": true,
+              "daily": 60.42516213095239,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1239.4065371,
+              "hasRDI": true,
+              "daily": 26.37035185319149,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 15.235705527750003,
+              "hasRDI": true,
+              "daily": 84.64280848750002,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 7.3480551279999995,
+              "hasRDI": true,
+              "daily": 66.80050116363635,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 956.3452087750002,
+              "hasRDI": true,
+              "daily": 136.62074411071433,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 72.83302717500001,
+              "hasRDI": true,
+              "daily": 8.092558575000002,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 9.384,
+              "hasRDI": true,
+              "daily": 10.426666666666668,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 3.9159386640750005,
+              "hasRDI": true,
+              "daily": 326.3282220062501,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.5964031221500001,
+              "hasRDI": true,
+              "daily": 122.80024016538462,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 30.173544053925003,
+              "hasRDI": true,
+              "daily": 188.58465033703126,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.9956696394000001,
+              "hasRDI": true,
+              "daily": 76.58997226153846,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 1287.20382675,
+              "hasRDI": true,
+              "daily": 321.8009566875,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 127.141340475,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 683.7904977750001,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.98656340475,
+              "hasRDI": true,
+              "daily": 41.10680853125,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 37.421370525,
+              "hasRDI": true,
+              "daily": 249.4758035,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 12.17496882675,
+              "hasRDI": true,
+              "daily": 81.16645884500001,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 111.0860213875,
+              "hasRDI": true,
+              "daily": 92.57168448958333,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_6f88a8ef43b3b2ff88a9e84b7aa8257f",
+          "label": "Gingered Sesame Noodles",
+          "image": "https://www.edamam.com/web-img/c38/c382a6c87890469f1a42121805c0058f.jpg",
+          "source": "French Revolution Food",
+          "url": "http://www.frenchrevolutionfood.com/2011/06/the-secret-ingredient-ginger-jam-gingered-sesame-noodles/",
+          "shareAs": "http://www.edamam.com/recipe/gingered-sesame-noodles-6f88a8ef43b3b2ff88a9e84b7aa8257f/noodles",
+          "yield": 4.0,
+          "dietLabels": [
+            "Balanced"
+          ],
+          "healthLabels": [
+            "Vegetarian",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1 pound wide lo mein noodles",
+            "6 tablespoons smooth peanut butter",
+            "3 tablespoons soy sauce",
+            "3 tablespoon toasted sesame oil",
+            "3 tablespoon boiling water",
+            "3 tablespoon ginger jam",
+            "1/2 teaspoon dried red pepper flakes",
+            "2 teaspoons sesame seeds",
+            "4 teaspoon rice vinegar",
+            "2 scallions, chopped"
+          ],
+          "ingredients": [
+            {
+              "text": "1 pound wide lo mein noodles",
+              "weight": 453.59237
+            },
+            {
+              "text": "6 tablespoons smooth peanut butter",
+              "weight": 96.0
+            },
+            {
+              "text": "3 tablespoons soy sauce",
+              "weight": 48.0
+            },
+            {
+              "text": "3 tablespoon toasted sesame oil",
+              "weight": 40.8
+            },
+            {
+              "text": "3 tablespoon boiling water",
+              "weight": 44.360294343
+            },
+            {
+              "text": "3 tablespoon ginger jam",
+              "weight": 60.0
+            },
+            {
+              "text": "1/2 teaspoon dried red pepper flakes",
+              "weight": 0.9
+            },
+            {
+              "text": "2 teaspoons sesame seeds",
+              "weight": 6.000000000304327
+            },
+            {
+              "text": "4 teaspoon rice vinegar",
+              "weight": 20.0
+            },
+            {
+              "text": "2 scallions, chopped",
+              "weight": 30.0
+            }
+          ],
+          "calories": 2919.228700801744,
+          "totalWeight": 799.6526643433043,
+          "totalTime": 20.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2919.228700801744,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 113.75333122815115,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 21.55538996602117,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.34869134570000004,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 48.00336647245708,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 36.61466444476626,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 392.5019520990714,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 22.545348210035915,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 48.70799655600091,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 29.099999999999998,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 91.40036959205398,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 381.01759080000005,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 2775.318809473754,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 317.60013833325723,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 491.35517754449813,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 2026.8513828014243,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 22.242654037044282,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 12.182929533457887,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 1558.1146117019143,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 110.8397029,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 11.6076,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 5.3755535521024065,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 2.2885144962007518,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 52.21270107191374,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 1.5739095192024042,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 1801.1057690002954,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 254.3557873002952,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 911.7206637000002,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 1.3154178730000001,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 49.895160700000005,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 11.505961769000757,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 70.92746184999999,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 145.96143504008717,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 175.00512496638638,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 107.77694983010585,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 130.8339840330238,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 90.18139284014366,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 182.80073918410795,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 127.00586360000001,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 115.63828372807308,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 31.760013833325722,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 116.98932798678527,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 43.12449750641328,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 123.57030020580156,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 110.75390484961714,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 222.58780167170207,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 12.315522544444446,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 12.897333333333334,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 447.9627960085339,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 176.03957663082707,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 326.3293816994609,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 121.06996301556954,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 450.27644225007384,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 54.80907804166667,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 332.6344046666667,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 76.70641179333839,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 59.10621820833332,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 113.75333122815115,
+              "hasRDI": true,
+              "daily": 175.00512496638638,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 21.55538996602117,
+                  "hasRDI": true,
+                  "daily": 107.77694983010585,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.34869134570000004,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 48.00336647245708,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 36.61466444476626,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 392.5019520990714,
+              "hasRDI": true,
+              "daily": 130.8339840330238,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 369.9566038890355,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 22.545348210035915,
+                  "hasRDI": true,
+                  "daily": 90.18139284014366,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 48.70799655600091,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 29.099999999999998,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 91.40036959205398,
+              "hasRDI": true,
+              "daily": 182.80073918410795,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 381.01759080000005,
+              "hasRDI": true,
+              "daily": 127.00586360000001,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 2775.318809473754,
+              "hasRDI": true,
+              "daily": 115.63828372807308,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 317.60013833325723,
+              "hasRDI": true,
+              "daily": 31.760013833325722,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 491.35517754449813,
+              "hasRDI": true,
+              "daily": 116.98932798678527,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 2026.8513828014243,
+              "hasRDI": true,
+              "daily": 43.12449750641328,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 22.242654037044282,
+              "hasRDI": true,
+              "daily": 123.57030020580156,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 12.182929533457887,
+              "hasRDI": true,
+              "daily": 110.75390484961714,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 1558.1146117019143,
+              "hasRDI": true,
+              "daily": 222.58780167170207,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 110.8397029,
+              "hasRDI": true,
+              "daily": 12.315522544444446,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 11.6076,
+              "hasRDI": true,
+              "daily": 12.897333333333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 5.3755535521024065,
+              "hasRDI": true,
+              "daily": 447.9627960085339,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 2.2885144962007518,
+              "hasRDI": true,
+              "daily": 176.03957663082707,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 52.21270107191374,
+              "hasRDI": true,
+              "daily": 326.3293816994609,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 1.5739095192024042,
+              "hasRDI": true,
+              "daily": 121.06996301556954,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 1801.1057690002954,
+              "hasRDI": true,
+              "daily": 450.27644225007384,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 254.3557873002952,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 911.7206637000002,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 1.3154178730000001,
+              "hasRDI": true,
+              "daily": 54.80907804166667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 49.895160700000005,
+              "hasRDI": true,
+              "daily": 332.6344046666667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 11.505961769000757,
+              "hasRDI": true,
+              "daily": 76.70641179333839,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 70.92746184999999,
+              "hasRDI": true,
+              "daily": 59.10621820833332,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_31c5de9edb4e2e9cc47997030647930d",
+          "label": "Glazed Drumsticks With Rice Noodles",
+          "image": "https://www.edamam.com/web-img/26f/26f7416656d3b5bd35cf63ffc82e680e.jpg",
+          "source": "Real Simple",
+          "url": "https://www.realsimple.com/food-recipes/browse-all-recipes/glazed-drumsticks",
+          "shareAs": "http://www.edamam.com/recipe/glazed-drumsticks-with-rice-noodles-31c5de9edb4e2e9cc47997030647930d/noodles",
+          "yield": 4.0,
+          "dietLabels": [],
+          "healthLabels": [
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "8 ounces rice noodles (often called pad thai noodles)",
+            "1 tablespoon canola oil",
+            "8  chicken drumsticks",
+            "Kosher salt and black pepper",
+            "1/4 cup low-sodium soy sauce",
+            "3 tablespoons rice vinegar",
+            "3 tablespoons brown sugar",
+            "1/4 head napa cabbage, sliced",
+            "2  scallions, sliced"
+          ],
+          "ingredients": [
+            {
+              "text": "8 ounces rice noodles (often called pad thai noodles)",
+              "weight": 226.796185
+            },
+            {
+              "text": "1 tablespoon canola oil",
+              "weight": 14.0
+            },
+            {
+              "text": "8  chicken drumsticks",
+              "weight": 1064.0
+            },
+            {
+              "text": "Kosher salt and black pepper",
+              "weight": 0.0
+            },
+            {
+              "text": "Kosher salt and black pepper",
+              "weight": 5.041301054998621
+            },
+            {
+              "text": "1/4 cup low-sodium soy sauce",
+              "weight": 63.75
+            },
+            {
+              "text": "3 tablespoons rice vinegar",
+              "weight": 44.7
+            },
+            {
+              "text": "3 tablespoons brown sugar",
+              "weight": 27.187499999540343
+            },
+            {
+              "text": "1/4 head napa cabbage, sliced",
+              "weight": 210.0
+            },
+            {
+              "text": "2  scallions, sliced",
+              "weight": 30.0
+            }
+          ],
+          "calories": 2859.5877790463,
+          "totalWeight": 1685.474986054539,
+          "totalTime": 20.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 2859.5877790463,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 113.99065505039295,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 27.700645573735585,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 0.5553800000000001,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 48.92932353854644,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 25.549761462028886,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 223.26921690722077,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 8.23043812691465,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 30.195362248306036,
+              "unit": "g"
+            },
+            "SUGAR.added": {
+              "label": "Sugars, added",
+              "quantity": 26.37731249955404,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 215.89036418711382,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 978.8800000000001,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 3985.1488169108716,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 434.7489019732624,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 320.13754200400626,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 3253.53112152032,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 12.822549877437103,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 22.56093450155435,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 2286.7839187168793,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 633.6211512848497,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 100.14,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 1.0848714224893985,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 2.446429693348998,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 54.03123788990813,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 4.258336488819857,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 225.70278172934516,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 225.70278172934516,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 5.639200000000001,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 21.28,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 5.383280334471986,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 202.48460982703273,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 142.979388952315,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 175.37023853906607,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 138.50322786867793,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 74.42307230240692,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 32.9217525076586,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 431.78072837422764,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 326.2933333333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 166.04786737128632,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 43.47489019732624,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 76.22322428666816,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 69.22406641532596,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 71.23638820798391,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 205.09940455958497,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 326.68341695955417,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 70.40235014276108,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 111.26666666666667,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 90.40595187411654,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 188.18689948838446,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 337.6952368119258,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 327.5643452938352,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 56.42569543233629,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 234.9666666666667,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 141.86666666666667,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 35.888535563146576,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 168.73717485586062,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 113.99065505039295,
+              "hasRDI": true,
+              "daily": 175.37023853906607,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 27.700645573735585,
+                  "hasRDI": true,
+                  "daily": 138.50322786867793,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 0.5553800000000001,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 48.92932353854644,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 25.549761462028886,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 223.26921690722077,
+              "hasRDI": true,
+              "daily": 74.42307230240692,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 215.0387787803061,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 8.23043812691465,
+                  "hasRDI": true,
+                  "daily": 32.9217525076586,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 30.195362248306036,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 26.37731249955404,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 215.89036418711382,
+              "hasRDI": true,
+              "daily": 431.78072837422764,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 978.8800000000001,
+              "hasRDI": true,
+              "daily": 326.2933333333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 3985.1488169108716,
+              "hasRDI": true,
+              "daily": 166.04786737128632,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 434.7489019732624,
+              "hasRDI": true,
+              "daily": 43.47489019732624,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 320.13754200400626,
+              "hasRDI": true,
+              "daily": 76.22322428666816,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 3253.53112152032,
+              "hasRDI": true,
+              "daily": 69.22406641532596,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 12.822549877437103,
+              "hasRDI": true,
+              "daily": 71.23638820798391,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 22.56093450155435,
+              "hasRDI": true,
+              "daily": 205.09940455958497,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 2286.7839187168793,
+              "hasRDI": true,
+              "daily": 326.68341695955417,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 633.6211512848497,
+              "hasRDI": true,
+              "daily": 70.40235014276108,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 100.14,
+              "hasRDI": true,
+              "daily": 111.26666666666667,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 1.0848714224893985,
+              "hasRDI": true,
+              "daily": 90.40595187411654,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 2.446429693348998,
+              "hasRDI": true,
+              "daily": 188.18689948838446,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 54.03123788990813,
+              "hasRDI": true,
+              "daily": 337.6952368119258,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 4.258336488819857,
+              "hasRDI": true,
+              "daily": 327.5643452938352,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 225.70278172934516,
+              "hasRDI": true,
+              "daily": 56.42569543233629,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 225.70278172934516,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 0.0,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 5.639200000000001,
+              "hasRDI": true,
+              "daily": 234.9666666666667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 21.28,
+              "hasRDI": true,
+              "daily": 141.86666666666667,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 5.383280334471986,
+              "hasRDI": true,
+              "daily": 35.888535563146576,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 202.48460982703273,
+              "hasRDI": true,
+              "daily": 168.73717485586062,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      },
+      {
+        "recipe": {
+          "uri": "http://www.edamam.com/ontologies/edamam.owl#recipe_90f16b830a07777f88fd3b2b5c5eb472",
+          "label": "Egg Noodles with Mushrooms",
+          "image": "https://www.edamam.com/web-img/6bd/6bd8b8770fe1f0517954d49b9b3bf47c.jpeg",
+          "source": "Food Network",
+          "url": "https://www.foodnetwork.com/recipes/rachael-ray/egg-noodles-with-mushrooms-recipe-1911793",
+          "shareAs": "http://www.edamam.com/recipe/egg-noodles-with-mushrooms-90f16b830a07777f88fd3b2b5c5eb472/noodles",
+          "yield": 4.0,
+          "dietLabels": [
+            "Balanced"
+          ],
+          "healthLabels": [
+            "Sugar-Conscious",
+            "Vegetarian",
+            "Peanut-Free",
+            "Tree-Nut-Free",
+            "Alcohol-Free"
+          ],
+          "cautions": [
+            "Sulfites"
+          ],
+          "ingredientLines": [
+            "1/2 pound wide egg noodles",
+            "2 tablespoons butter",
+            "8 white mushrooms, sliced",
+            "1 shallot, finely chopped",
+            "A handful fresh parsley, chopped",
+            "Salt"
+          ],
+          "ingredients": [
+            {
+              "text": "1/2 pound wide egg noodles",
+              "weight": 226.796185
+            },
+            {
+              "text": "2 tablespoons butter",
+              "weight": 28.4
+            },
+            {
+              "text": "8 white mushrooms, sliced",
+              "weight": 144.0
+            },
+            {
+              "text": "1 shallot, finely chopped",
+              "weight": 59.111111111111114
+            },
+            {
+              "text": "A handful fresh parsley, chopped",
+              "weight": 15.0
+            },
+            {
+              "text": "Salt",
+              "weight": 2.8398437766666667
+            }
+          ],
+          "calories": 1154.1653504,
+          "totalWeight": 475.957644732756,
+          "totalTime": 15.0,
+          "totalNutrients": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 1154.1653504,
+              "unit": "kcal"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 33.77220172511112,
+              "unit": "g"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 17.366555871888888,
+              "unit": "g"
+            },
+            "FATRN": {
+              "label": "Trans",
+              "quantity": 1.0692976728499999,
+              "unit": "g"
+            },
+            "FAMS": {
+              "label": "Monounsaturated",
+              "quantity": 8.861977791755555,
+              "unit": "g"
+            },
+            "FAPU": {
+              "label": "Polyunsaturated",
+              "quantity": 4.154922555683334,
+              "unit": "g"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 177.2292477161667,
+              "unit": "g"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 11.310829660555555,
+              "unit": "g"
+            },
+            "SUGAR": {
+              "label": "Sugars",
+              "quantity": 11.911552722444446,
+              "unit": "g"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 38.728617573777775,
+              "unit": "g"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 251.56879540000003,
+              "unit": "mg"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 1100.666650960467,
+              "unit": "mg"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 133.7218595303059,
+              "unit": "mg"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 165.0096241195498,
+              "unit": "mg"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 1298.8618304008428,
+              "unit": "mg"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 11.468286502284762,
+              "unit": "mg"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 5.528441545066089,
+              "unit": "mg"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 721.4014725166669,
+              "unit": "mg"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 295.96135144999994,
+              "unit": "µg"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 27.70288888888889,
+              "unit": "mg"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 2.736027442716667,
+              "unit": "mg"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 1.5812099703222222,
+              "unit": "mg"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 24.54257625817223,
+              "unit": "mg"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 0.8579250929333333,
+              "unit": "mg"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 907.3756622777778,
+              "unit": "µg"
+            },
+            "FOLFD": {
+              "label": "Folate (food)",
+              "quantity": 134.0006714277778,
+              "unit": "µg"
+            },
+            "FOLAC": {
+              "label": "Folic acid",
+              "quantity": 455.8603318500001,
+              "unit": "µg"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 0.7635889365,
+              "unit": "µg"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 52.06758035,
+              "unit": "IU"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 1.6485703289444444,
+              "unit": "mg"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 249.5948698138889,
+              "unit": "µg"
+            }
+          },
+          "totalDaily": {
+            "ENERC_KCAL": {
+              "label": "Energy",
+              "quantity": 57.70826752,
+              "unit": "%"
+            },
+            "FAT": {
+              "label": "Fat",
+              "quantity": 51.95723342324787,
+              "unit": "%"
+            },
+            "FASAT": {
+              "label": "Saturated",
+              "quantity": 86.83277935944444,
+              "unit": "%"
+            },
+            "CHOCDF": {
+              "label": "Carbs",
+              "quantity": 59.07641590538889,
+              "unit": "%"
+            },
+            "FIBTG": {
+              "label": "Fiber",
+              "quantity": 45.24331864222222,
+              "unit": "%"
+            },
+            "PROCNT": {
+              "label": "Protein",
+              "quantity": 77.45723514755555,
+              "unit": "%"
+            },
+            "CHOLE": {
+              "label": "Cholesterol",
+              "quantity": 83.85626513333334,
+              "unit": "%"
+            },
+            "NA": {
+              "label": "Sodium",
+              "quantity": 45.86111045668612,
+              "unit": "%"
+            },
+            "CA": {
+              "label": "Calcium",
+              "quantity": 13.372185953030588,
+              "unit": "%"
+            },
+            "MG": {
+              "label": "Magnesium",
+              "quantity": 39.28800574274995,
+              "unit": "%"
+            },
+            "K": {
+              "label": "Potassium",
+              "quantity": 27.635358093634952,
+              "unit": "%"
+            },
+            "FE": {
+              "label": "Iron",
+              "quantity": 63.7127027904709,
+              "unit": "%"
+            },
+            "ZN": {
+              "label": "Zinc",
+              "quantity": 50.25855950060081,
+              "unit": "%"
+            },
+            "P": {
+              "label": "Phosphorus",
+              "quantity": 103.0573532166667,
+              "unit": "%"
+            },
+            "VITA_RAE": {
+              "label": "Vitamin A",
+              "quantity": 32.88459460555555,
+              "unit": "%"
+            },
+            "VITC": {
+              "label": "Vitamin C",
+              "quantity": 30.780987654320988,
+              "unit": "%"
+            },
+            "THIA": {
+              "label": "Thiamin (B1)",
+              "quantity": 228.00228689305555,
+              "unit": "%"
+            },
+            "RIBF": {
+              "label": "Riboflavin (B2)",
+              "quantity": 121.63153617863247,
+              "unit": "%"
+            },
+            "NIA": {
+              "label": "Niacin (B3)",
+              "quantity": 153.39110161357644,
+              "unit": "%"
+            },
+            "VITB6A": {
+              "label": "Vitamin B6",
+              "quantity": 65.99423791794871,
+              "unit": "%"
+            },
+            "FOLDFE": {
+              "label": "Folate equivalent (total)",
+              "quantity": 226.84391556944445,
+              "unit": "%"
+            },
+            "VITB12": {
+              "label": "Vitamin B12",
+              "quantity": 31.816205687500002,
+              "unit": "%"
+            },
+            "VITD": {
+              "label": "Vitamin D",
+              "quantity": 347.1172023333333,
+              "unit": "%"
+            },
+            "TOCPHA": {
+              "label": "Vitamin E",
+              "quantity": 10.99046885962963,
+              "unit": "%"
+            },
+            "VITK1": {
+              "label": "Vitamin K",
+              "quantity": 207.99572484490741,
+              "unit": "%"
+            }
+          },
+          "digest": [
+            {
+              "label": "Fat",
+              "tag": "FAT",
+              "schemaOrgTag": "fatContent",
+              "total": 33.77220172511112,
+              "hasRDI": true,
+              "daily": 51.95723342324787,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Saturated",
+                  "tag": "FASAT",
+                  "schemaOrgTag": "saturatedFatContent",
+                  "total": 17.366555871888888,
+                  "hasRDI": true,
+                  "daily": 86.83277935944444,
+                  "unit": "g"
+                },
+                {
+                  "label": "Trans",
+                  "tag": "FATRN",
+                  "schemaOrgTag": "transFatContent",
+                  "total": 1.0692976728499999,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Monounsaturated",
+                  "tag": "FAMS",
+                  "schemaOrgTag": null,
+                  "total": 8.861977791755555,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Polyunsaturated",
+                  "tag": "FAPU",
+                  "schemaOrgTag": null,
+                  "total": 4.154922555683334,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Carbs",
+              "tag": "CHOCDF",
+              "schemaOrgTag": "carbohydrateContent",
+              "total": 177.2292477161667,
+              "hasRDI": true,
+              "daily": 59.07641590538889,
+              "unit": "g",
+              "sub": [
+                {
+                  "label": "Carbs (net)",
+                  "tag": "CHOCDF.net",
+                  "schemaOrgTag": null,
+                  "total": 165.91841805561114,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Fiber",
+                  "tag": "FIBTG",
+                  "schemaOrgTag": "fiberContent",
+                  "total": 11.310829660555555,
+                  "hasRDI": true,
+                  "daily": 45.24331864222222,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars",
+                  "tag": "SUGAR",
+                  "schemaOrgTag": "sugarContent",
+                  "total": 11.911552722444446,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                },
+                {
+                  "label": "Sugars, added",
+                  "tag": "SUGAR.added",
+                  "schemaOrgTag": null,
+                  "total": 0.0,
+                  "hasRDI": false,
+                  "daily": 0.0,
+                  "unit": "g"
+                }
+              ]
+            },
+            {
+              "label": "Protein",
+              "tag": "PROCNT",
+              "schemaOrgTag": "proteinContent",
+              "total": 38.728617573777775,
+              "hasRDI": true,
+              "daily": 77.45723514755555,
+              "unit": "g"
+            },
+            {
+              "label": "Cholesterol",
+              "tag": "CHOLE",
+              "schemaOrgTag": "cholesterolContent",
+              "total": 251.56879540000003,
+              "hasRDI": true,
+              "daily": 83.85626513333334,
+              "unit": "mg"
+            },
+            {
+              "label": "Sodium",
+              "tag": "NA",
+              "schemaOrgTag": "sodiumContent",
+              "total": 1100.666650960467,
+              "hasRDI": true,
+              "daily": 45.86111045668612,
+              "unit": "mg"
+            },
+            {
+              "label": "Calcium",
+              "tag": "CA",
+              "schemaOrgTag": null,
+              "total": 133.7218595303059,
+              "hasRDI": true,
+              "daily": 13.372185953030588,
+              "unit": "mg"
+            },
+            {
+              "label": "Magnesium",
+              "tag": "MG",
+              "schemaOrgTag": null,
+              "total": 165.0096241195498,
+              "hasRDI": true,
+              "daily": 39.28800574274995,
+              "unit": "mg"
+            },
+            {
+              "label": "Potassium",
+              "tag": "K",
+              "schemaOrgTag": null,
+              "total": 1298.8618304008428,
+              "hasRDI": true,
+              "daily": 27.635358093634952,
+              "unit": "mg"
+            },
+            {
+              "label": "Iron",
+              "tag": "FE",
+              "schemaOrgTag": null,
+              "total": 11.468286502284762,
+              "hasRDI": true,
+              "daily": 63.7127027904709,
+              "unit": "mg"
+            },
+            {
+              "label": "Zinc",
+              "tag": "ZN",
+              "schemaOrgTag": null,
+              "total": 5.528441545066089,
+              "hasRDI": true,
+              "daily": 50.25855950060081,
+              "unit": "mg"
+            },
+            {
+              "label": "Phosphorus",
+              "tag": "P",
+              "schemaOrgTag": null,
+              "total": 721.4014725166669,
+              "hasRDI": true,
+              "daily": 103.0573532166667,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin A",
+              "tag": "VITA_RAE",
+              "schemaOrgTag": null,
+              "total": 295.96135144999994,
+              "hasRDI": true,
+              "daily": 32.88459460555555,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin C",
+              "tag": "VITC",
+              "schemaOrgTag": null,
+              "total": 27.70288888888889,
+              "hasRDI": true,
+              "daily": 30.780987654320988,
+              "unit": "mg"
+            },
+            {
+              "label": "Thiamin (B1)",
+              "tag": "THIA",
+              "schemaOrgTag": null,
+              "total": 2.736027442716667,
+              "hasRDI": true,
+              "daily": 228.00228689305555,
+              "unit": "mg"
+            },
+            {
+              "label": "Riboflavin (B2)",
+              "tag": "RIBF",
+              "schemaOrgTag": null,
+              "total": 1.5812099703222222,
+              "hasRDI": true,
+              "daily": 121.63153617863247,
+              "unit": "mg"
+            },
+            {
+              "label": "Niacin (B3)",
+              "tag": "NIA",
+              "schemaOrgTag": null,
+              "total": 24.54257625817223,
+              "hasRDI": true,
+              "daily": 153.39110161357644,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin B6",
+              "tag": "VITB6A",
+              "schemaOrgTag": null,
+              "total": 0.8579250929333333,
+              "hasRDI": true,
+              "daily": 65.99423791794871,
+              "unit": "mg"
+            },
+            {
+              "label": "Folate equivalent (total)",
+              "tag": "FOLDFE",
+              "schemaOrgTag": null,
+              "total": 907.3756622777778,
+              "hasRDI": true,
+              "daily": 226.84391556944445,
+              "unit": "µg"
+            },
+            {
+              "label": "Folate (food)",
+              "tag": "FOLFD",
+              "schemaOrgTag": null,
+              "total": 134.0006714277778,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Folic acid",
+              "tag": "FOLAC",
+              "schemaOrgTag": null,
+              "total": 455.8603318500001,
+              "hasRDI": false,
+              "daily": 0.0,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin B12",
+              "tag": "VITB12",
+              "schemaOrgTag": null,
+              "total": 0.7635889365,
+              "hasRDI": true,
+              "daily": 31.816205687500002,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin D",
+              "tag": "VITD",
+              "schemaOrgTag": null,
+              "total": 52.06758035,
+              "hasRDI": true,
+              "daily": 347.1172023333333,
+              "unit": "µg"
+            },
+            {
+              "label": "Vitamin E",
+              "tag": "TOCPHA",
+              "schemaOrgTag": null,
+              "total": 1.6485703289444444,
+              "hasRDI": true,
+              "daily": 10.99046885962963,
+              "unit": "mg"
+            },
+            {
+              "label": "Vitamin K",
+              "tag": "VITK1",
+              "schemaOrgTag": null,
+              "total": 249.5948698138889,
+              "hasRDI": true,
+              "daily": 207.99572484490741,
+              "unit": "µg"
+            }
+          ]
+        },
+        "bookmarked": false,
+        "bought": false
+      }
+    ]
+  }
+}

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -93,4 +93,49 @@ router.get('/calorie_search', async (req, res, next) => {
     });
 });
 
+router.get('/time_search', async (req, res, next) => {
+  res.setHeader('Content-Type', 'application/json')
+  let createdRecipes = []
+
+  await recipe.findAll({
+    where: {
+      foodType: req.query.q,
+      totalTime: { [Op.lte]: req.query.max },
+    }
+  })
+    .then(async recipes => {
+      if (recipes.length === 0) {
+        let edamam = await new edamamService(req.query.q);
+        let max = req.query.max
+
+        await edamam.getRecipesByTime(max)
+          .then(async edamamResponse => {
+            let edamamRecipes = await edamamResponse.hits;
+            for (let i = 0; i < edamamRecipes.length; i++) {
+              let result = edamamRecipes[i];
+              await recipe.create({
+                name: result.recipe.label,
+                foodType: req.query.q,
+                image: result.recipe.image,
+                url: result.recipe.url,
+                calories: result.recipe.calories,
+                totalTime: result.recipe.totalTime,
+                yield: result.recipe.yield,
+                ingredients: result.recipe.ingredientLines
+              })
+                .then(async recipe =>
+                  createdRecipes.push(recipe)
+                );
+            };
+          });
+        res.status(200).send(createdRecipes)
+        return;
+      };
+      res.status(200).send(recipes)
+    })
+    .catch(async error => {
+      res.status(500).send( {error} )
+    });
+});
+
 module.exports = router;

--- a/services/edamam_service.js
+++ b/services/edamam_service.js
@@ -36,6 +36,21 @@ class EdamamService {
         return error
       })
   }
+
+  async getRecipesByTime(max) {
+    const url = 'https://api.edamam.com/search?'
+    const app_id = `app_id=${id}&`
+    const app_key = `app_key=${key}&`
+    const params = `q=${this.foodType}&to=10&time=1-${max}`
+
+    return await axios.get(`${url}${app_id}${app_key}${params}`)
+      .then(async response => {
+        return await response.data
+      })
+      .catch(async error => {
+        return error
+      })
+  }
 }
 
 module.exports = { EdamamService: EdamamService }

--- a/tests/recipes/get_time_search_request.spec.js
+++ b/tests/recipes/get_time_search_request.spec.js
@@ -1,0 +1,37 @@
+const shell = require('shelljs');
+const request = require('supertest');
+const app = require('../../app');
+const timeResponse = require("../../__fixtures__/time_recipes");
+const mockAxios = require('axios');
+const recipe = require('../../models').Recipe;
+
+describe('Recipes API', () => {
+  describe('Time search GET request', () => {
+    beforeEach(async () => {
+      await recipe.destroy({where: {}});
+    });
+    afterEach(async () => {
+      await recipe.destroy({where: {}});
+    });
+
+    test('It returns a list of recipes by max total cook/prep time', () => {
+      mockAxios.get.mockImplementationOnce(() =>
+        Promise.resolve(timeResponse)
+      );
+
+      return request(app).get('/api/v1/recipes/time_search?q=tongue&max=20')
+        .then(response => {
+          expect(response.status).toBe(200)
+          expect(response.body.length).toBe(10)
+          expect(Object.keys(response.body[0])).toContain("id")
+          expect(Object.keys(response.body[0])).toContain("name")
+          expect(Object.keys(response.body[0])).toContain("image")
+          expect(Object.keys(response.body[0])).toContain("yield")
+          expect(Object.keys(response.body[0])).toContain("url")
+          expect(Object.keys(response.body[0])).toContain("ingredients")
+          expect(Object.keys(response.body[0])).toContain("calories")
+          expect(Object.keys(response.body[0])).toContain("totalTime")
+        });
+    });
+  });
+});


### PR DESCRIPTION
- Able to send GET request to `'/api/v1/recipes/time_search?q=<food_type>&max=<time_in_minutes>'` to receive recipes with `totalTime` less than given max time.
- Closes #6 